### PR TITLE
Refactor/#100 watchlist

### DIFF
--- a/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/watchlist/WatchlistController.java
+++ b/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/watchlist/WatchlistController.java
@@ -2,18 +2,18 @@ package org.stockwellness.adapter.in.web.watchlist;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.stockwellness.adapter.in.web.watchlist.dto.AddWatchlistItemRequest;
 import org.stockwellness.adapter.in.web.watchlist.dto.CreateWatchlistGroupRequest;
+import org.stockwellness.adapter.in.web.watchlist.dto.UpdateWatchlistItemNoteRequest;
 import org.stockwellness.application.port.in.watchlist.dto.WatchlistGroupResponse;
 import org.stockwellness.application.port.in.watchlist.dto.WatchlistItemListResponse;
 import org.stockwellness.application.port.in.watchlist.WatchlistUseCase;
 import org.stockwellness.global.security.MemberPrincipal;
 
-import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -24,23 +24,16 @@ public class WatchlistController {
     private final WatchlistUseCase watchlistUseCase;
 
     @PostMapping("/groups")
-    public ResponseEntity<Void> createGroup(
+    public ResponseEntity<Long> createGroup(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @RequestBody @Valid CreateWatchlistGroupRequest request) {
-
         Long groupId = watchlistUseCase.createGroup(memberPrincipal.id(), request.name());
-
-        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
-                .path("/{id}")
-                .buildAndExpand(groupId)
-                .toUri();
-        return ResponseEntity.created(location).build();
+        return ResponseEntity.status(HttpStatus.CREATED).body(groupId);
     }
 
     @GetMapping("/groups")
     public ResponseEntity<List<WatchlistGroupResponse>> getGroups(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
-
         List<WatchlistGroupResponse> response = watchlistUseCase.getGroups(memberPrincipal.id());
         return ResponseEntity.ok(response);
     }
@@ -50,7 +43,6 @@ public class WatchlistController {
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @PathVariable Long groupId,
             @RequestBody @Valid CreateWatchlistGroupRequest request) {
-
         watchlistUseCase.updateGroupName(memberPrincipal.id(), groupId, request.name());
         return ResponseEntity.noContent().build();
     }
@@ -59,7 +51,6 @@ public class WatchlistController {
     public ResponseEntity<Void> deleteGroup(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @PathVariable Long groupId) {
-
         watchlistUseCase.deleteGroup(memberPrincipal.id(), groupId);
         return ResponseEntity.noContent().build();
     }
@@ -69,18 +60,26 @@ public class WatchlistController {
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @PathVariable Long groupId,
             @RequestBody @Valid AddWatchlistItemRequest request) {
-
-        watchlistUseCase.addItem(memberPrincipal.id(), groupId, request.isinCode());
-        return ResponseEntity.noContent().build();
+        watchlistUseCase.addItem(memberPrincipal.id(), groupId, request.ticker(), request.note());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @DeleteMapping("/groups/{groupId}/items/{isinCode}")
+    @DeleteMapping("/groups/{groupId}/items/{ticker}")
     public ResponseEntity<Void> removeItem(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @PathVariable Long groupId,
-            @PathVariable String isinCode) {
+            @PathVariable String ticker) {
+        watchlistUseCase.removeItem(memberPrincipal.id(), groupId, ticker);
+        return ResponseEntity.noContent().build();
+    }
 
-        watchlistUseCase.removeItem(memberPrincipal.id(), groupId, isinCode);
+    @PatchMapping("/groups/{groupId}/items/{ticker}/note")
+    public ResponseEntity<Void> updateItemNote(
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+            @PathVariable Long groupId,
+            @PathVariable String ticker,
+            @RequestBody @Valid UpdateWatchlistItemNoteRequest request) {
+        watchlistUseCase.updateItemNote(memberPrincipal.id(), groupId, ticker, request.note());
         return ResponseEntity.noContent().build();
     }
 
@@ -88,7 +87,6 @@ public class WatchlistController {
     public ResponseEntity<WatchlistItemListResponse> getItems(
             @AuthenticationPrincipal MemberPrincipal memberPrincipal,
             @PathVariable Long groupId) {
-
         WatchlistItemListResponse response = watchlistUseCase.getItems(memberPrincipal.id(), groupId);
         return ResponseEntity.ok(response);
     }

--- a/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/watchlist/dto/UpdateWatchlistItemNoteRequest.java
+++ b/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/watchlist/dto/UpdateWatchlistItemNoteRequest.java
@@ -1,12 +1,8 @@
 package org.stockwellness.adapter.in.web.watchlist.dto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record AddWatchlistItemRequest(
-        @NotBlank(message = "티커는 필수입니다.")
-        String ticker,
-
+public record UpdateWatchlistItemNoteRequest(
         @Size(max = 200, message = "메모는 최대 200자까지 입력할 수 있습니다.")
         String note
 ) {

--- a/stockwellness-api/src/main/resources/static/docs/openapi3.yaml
+++ b/stockwellness-api/src/main/resources/static/docs/openapi3.yaml
@@ -282,16 +282,16 @@ paths:
                         "status" : "ACTIVE"
                       } ],
                       "pageable" : "INSTANCE",
+                      "first" : true,
+                      "last" : true,
+                      "numberOfElements" : 1,
                       "size" : 1,
                       "number" : 0,
                       "sort" : {
-                        "empty" : true,
+                        "sorted" : false,
                         "unsorted" : true,
-                        "sorted" : false
+                        "empty" : true
                       },
-                      "numberOfElements" : 1,
-                      "first" : true,
-                      "last" : true,
                       "empty" : false
                     }
   /api/v1/watchlist/groups:
@@ -356,6 +356,13 @@ paths:
       responses:
         "201":
           description: "201"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-watchlist-groups486549215"
+              examples:
+                watchlist-group-create:
+                  value: "10"
   /api/v1/sectors/ranking/fluctuation:
     get:
       tags:
@@ -490,7 +497,7 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/api-v1-portfolios-portfolioId-analysis-correlation486549215"
+              $ref: "#/components/schemas/api-v1-watchlist-groups486549215"
             examples:
               stock-search-history-delete:
                 value: keyword=%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90
@@ -553,14 +560,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-portfolios-portfolioId-advice-latest-701553720"
+                $ref: "#/components/schemas/api-v1-portfolios-portfolioId-advice-latest993826579"
               examples:
                 portfolio-advice-latest:
                   value: |-
                     {
-                      "content" : "상세 조언 내용입니다.",
-                      "action" : "REBALANCE",
-                      "createdAt" : "2026-03-11T19:38:52.777171"
+                      "data" : {
+                        "content" : "상세 조언 내용입니다.",
+                        "action" : "REBALANCE",
+                        "createdAt" : "2026-03-13T18:12:09.336509"
+                      },
+                      "timestamp" : "2026-03-13T18:12:09.338044"
                     }
   /api/v1/portfolios/{portfolioId}/analysis/backtest:
     post:
@@ -634,18 +644,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-portfolios-portfolioId-analysis-correlation486549215"
+                $ref: "#/components/schemas/api-v1-watchlist-groups486549215"
               examples:
                 portfolio-analysis-correlation:
                   value: |-
                     {
-                      "AAPL" : {
-                        "AAPL" : 1,
-                        "TSLA" : 0.85
-                      },
                       "TSLA" : {
-                        "AAPL" : 0.85,
-                        "TSLA" : 1
+                        "TSLA" : 1,
+                        "AAPL" : 0.85
+                      },
+                      "AAPL" : {
+                        "TSLA" : 0.85,
+                        "AAPL" : 1
                       }
                     }
   /api/v1/portfolios/{portfolioId}/analysis/diversification:
@@ -860,17 +870,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-watchlist-groups-groupId-items-332631838"
+                $ref: "#/components/schemas/api-v1-watchlist-groups-groupId-items-2016439498"
               examples:
                 watchlist-item-list:
                   value: |-
                     {
                       "groupName" : "테크주",
                       "items" : [ {
-                        "isinCode" : "KR7005930003",
+                        "ticker" : "005930",
                         "name" : "삼성전자",
                         "currentPrice" : 70000,
                         "fluctuationRate" : -1.2,
+                        "note" : "메모 내용",
                         "rsi" : 45,
                         "rsiStatus" : "중립",
                         "aiInsight" : "AI 요약 내용..."
@@ -900,12 +911,84 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/api-v1-watchlist-groups-groupId-items1982699150"
+              $ref: "#/components/schemas/api-v1-watchlist-groups-groupId-items-775687594"
             examples:
               watchlist-item-add:
                 value: |-
                   {
-                    "isinCode" : "KR7005930003"
+                    "ticker" : "005930",
+                    "note" : "삼성전자 메모"
+                  }
+      responses:
+        "201":
+          description: "201"
+  /api/v1/watchlist/groups/{groupId}/items/{ticker}:
+    delete:
+      tags:
+      - Watchlist
+      summary: 관심 종목 제거
+      description: 관심 종목 제거
+      operationId: watchlist-item-remove
+      parameters:
+      - name: groupId
+        in: path
+        description: 그룹 ID
+        required: true
+        schema:
+          type: string
+      - name: ticker
+        in: path
+        description: 종목 티커
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: Bearer Access Token
+        required: true
+        schema:
+          type: string
+        example: "Bearer {ACCESS_TOKEN}"
+      responses:
+        "204":
+          description: "204"
+  /api/v1/watchlist/groups/{groupId}/items/{ticker}/note:
+    patch:
+      tags:
+      - Watchlist
+      summary: 관심 종목 메모 수정
+      description: 관심 종목 메모 수정
+      operationId: watchlist-item-note-update
+      parameters:
+      - name: groupId
+        in: path
+        description: 그룹 ID
+        required: true
+        schema:
+          type: string
+      - name: ticker
+        in: path
+        description: 종목 티커
+        required: true
+        schema:
+          type: string
+      - name: Authorization
+        in: header
+        description: Bearer Access Token
+        required: true
+        schema:
+          type: string
+        example: "Bearer {ACCESS_TOKEN}"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api-v1-watchlist-groups-groupId-items-ticker-note-700261579"
+            examples:
+              watchlist-item-note-update:
+                value: |-
+                  {
+                    "note" : "수정된 메모"
                   }
       responses:
         "204":
@@ -1059,48 +1142,18 @@ components:
               value:
                 type: number
                 description: 비중 (%)
-    api-v1-watchlist-groups-groupId-items-332631838:
+    api-v1-watchlist-groups-groupId-items-775687594:
       required:
-      - groupName
+      - note
+      - ticker
       type: object
       properties:
-        groupName:
+        note:
           type: string
-          description: 그룹 이름
-        items:
-          type: array
-          items:
-            required:
-            - aiInsight
-            - currentPrice
-            - fluctuationRate
-            - isinCode
-            - name
-            - rsi
-            - rsiStatus
-            type: object
-            properties:
-              fluctuationRate:
-                type: number
-                description: 등락률
-              name:
-                type: string
-                description: 종목명
-              rsi:
-                type: number
-                description: RSI 지표
-              currentPrice:
-                type: number
-                description: 현재가
-              aiInsight:
-                type: string
-                description: AI 한줄 분석
-              rsiStatus:
-                type: string
-                description: RSI 상태
-              isinCode:
-                type: string
-                description: ISIN 코드
+          description: 투자 메모 (선택)
+        ticker:
+          type: string
+          description: 종목 티커
     api-v1-stocks-search-history457412190:
       type: array
       description: 최근 검색어 목록
@@ -1172,7 +1225,7 @@ components:
         stockReturnRate:
           type: number
           description: 종목 수익률 (%)
-    api-v1-portfolios-portfolioId-analysis-correlation486549215:
+    api-v1-watchlist-groups486549215:
       type: object
     SectorSupplyResponse:
       title: SectorSupplyResponse
@@ -1263,14 +1316,6 @@ components:
               currentQuantity:
                 type: number
                 description: 현재 보유 수량
-    api-v1-watchlist-groups-groupId-items1982699150:
-      required:
-      - isinCode
-      type: object
-      properties:
-        isinCode:
-          type: string
-          description: 종목 ISIN 코드
     api-v1-watchlist-groups288370516:
       required:
       - name
@@ -1430,23 +1475,6 @@ components:
         isOverheated:
           type: boolean
           description: 과열 진단 여부
-    api-v1-portfolios-portfolioId-advice-latest-701553720:
-      required:
-      - action
-      - content
-      - createdAt
-      type: object
-      properties:
-        createdAt:
-          type: string
-          description: 생성 일시
-        action:
-          type: string
-          description: "핵심 조언 액션 (REBALANCE, RISK_MANAGEMENT, TECHNICAL_OPTIMIZATION,\
-            \ DIVERSIFICATION)"
-        content:
-          type: string
-          description: 상세 조언 내용
     PortfolioValuationResponse:
       title: PortfolioValuationResponse
       required:
@@ -1488,6 +1516,33 @@ components:
         beta:
           type: number
           description: 베타 계수
+    api-v1-portfolios-portfolioId-advice-latest993826579:
+      required:
+      - data
+      - timestamp
+      type: object
+      properties:
+        data:
+          required:
+          - action
+          - content
+          - createdAt
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 생성 일시
+            action:
+              type: string
+              description: "핵심 조언 액션 (REBALANCE, RISK_MANAGEMENT, TECHNICAL_OPTIMIZATION,\
+                \ DIVERSIFICATION)"
+            content:
+              type: string
+              description: 상세 조언 내용
+          description: 응답 데이터
+        timestamp:
+          type: string
+          description: 응답 일시
     api-v1-stocks-ticker-prices-history-1525844804:
       required:
       - benchmarks
@@ -1583,6 +1638,60 @@ components:
           itemCount:
             type: number
             description: 포함된 종목 수
+    api-v1-watchlist-groups-groupId-items-ticker-note-700261579:
+      required:
+      - note
+      type: object
+      properties:
+        note:
+          type: string
+          description: 수정할 메모 내용
+    api-v1-watchlist-groups-groupId-items-2016439498:
+      required:
+      - groupName
+      type: object
+      properties:
+        groupName:
+          type: string
+          description: 그룹 이름
+        items:
+          type: array
+          items:
+            required:
+            - aiInsight
+            - currentPrice
+            - fluctuationRate
+            - name
+            - note
+            - rsi
+            - rsiStatus
+            - ticker
+            type: object
+            properties:
+              note:
+                type: string
+                description: 투자 메모
+              ticker:
+                type: string
+                description: 종목 티커
+              fluctuationRate:
+                type: number
+                description: 등락률
+              name:
+                type: string
+                description: 종목명
+              rsi:
+                type: number
+                description: RSI 지표
+              currentPrice:
+                type: number
+                description: 현재가
+              aiInsight:
+                type: string
+                description: AI 한줄 분석
+              rsiStatus:
+                type: string
+                description: RSI 상태
     ReissueResponse:
       title: ReissueResponse
       required:

--- a/stockwellness-api/src/test/java/org/stockwellness/adapter/in/web/watchlist/WatchlistControllerTest.java
+++ b/stockwellness-api/src/test/java/org/stockwellness/adapter/in/web/watchlist/WatchlistControllerTest.java
@@ -1,7 +1,6 @@
 package org.stockwellness.adapter.in.web.watchlist;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -94,7 +93,7 @@ class WatchlistControllerTest extends RestDocsSupport {
     @DisplayName("관심 그룹에 종목을 추가한다")
     void addItem() throws Exception {
         // given
-        AddWatchlistItemRequest request = new AddWatchlistItemRequest("KR7005930003");
+        AddWatchlistItemRequest request = new AddWatchlistItemRequest("005930", "삼성전자 메모");
 
         // when & then
         mockMvc.perform(post("/api/v1/watchlist/groups/{groupId}/items", 10L)
@@ -102,14 +101,68 @@ class WatchlistControllerTest extends RestDocsSupport {
                         .with(csrf())
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isNoContent())
+                .andExpect(status().isCreated())
                 .andDo(document("watchlist-item-add",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Watchlist")
                                 .summary("관심 종목 추가")
                                 .pathParameters(parameterWithName("groupId").description("그룹 ID"))
                                 .requestHeaders(headerWithName("Authorization").description("Bearer Access Token"))
-                                .requestFields(fieldWithPath("isinCode").description("종목 ISIN 코드"))
+                                .requestFields(
+                                        fieldWithPath("ticker").description("종목 티커"),
+                                        fieldWithPath("note").description("투자 메모 (선택)")
+                                )
+                                .build())
+                ));
+    }
+
+    @Test
+    @MockMember(id = 1L)
+    @DisplayName("관심 그룹 내 종목의 메모를 수정한다")
+    void updateItemNote() throws Exception {
+        // given
+        UpdateWatchlistItemNoteRequest request = new UpdateWatchlistItemNoteRequest("수정된 메모");
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/watchlist/groups/{groupId}/items/{ticker}/note", 10L, "005930")
+                        .header("Authorization", "Bearer {ACCESS_TOKEN}")
+                        .with(csrf())
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(document("watchlist-item-note-update",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Watchlist")
+                                .summary("관심 종목 메모 수정")
+                                .pathParameters(
+                                        parameterWithName("groupId").description("그룹 ID"),
+                                        parameterWithName("ticker").description("종목 티커")
+                                )
+                                .requestHeaders(headerWithName("Authorization").description("Bearer Access Token"))
+                                .requestFields(fieldWithPath("note").description("수정할 메모 내용"))
+                                .build())
+                ));
+    }
+
+    @Test
+    @MockMember(id = 1L)
+    @DisplayName("관심 그룹에서 종목을 제거한다")
+    void removeItem() throws Exception {
+        // when & then
+        mockMvc.perform(delete("/api/v1/watchlist/groups/{groupId}/items/{ticker}", 10L, "005930")
+                        .header("Authorization", "Bearer {ACCESS_TOKEN}")
+                        .with(csrf())
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isNoContent())
+                .andDo(document("watchlist-item-remove",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Watchlist")
+                                .summary("관심 종목 제거")
+                                .pathParameters(
+                                        parameterWithName("groupId").description("그룹 ID"),
+                                        parameterWithName("ticker").description("종목 티커")
+                                )
+                                .requestHeaders(headerWithName("Authorization").description("Bearer Access Token"))
                                 .build())
                 ));
     }
@@ -120,7 +173,7 @@ class WatchlistControllerTest extends RestDocsSupport {
     void getItems() throws Exception {
         // given
         WatchlistItemListResponse response = new WatchlistItemListResponse("테크주", List.of(
-                new WatchlistItemListResponse.WatchlistItemDetail("KR7005930003", "삼성전자", BigDecimal.valueOf(70000), BigDecimal.valueOf(-1.2), BigDecimal.valueOf(45), "중립", "AI 요약 내용...")
+                new WatchlistItemListResponse.WatchlistItemDetail("005930", "삼성전자", BigDecimal.valueOf(70000), BigDecimal.valueOf(-1.2), "메모 내용", BigDecimal.valueOf(45), "중립", "AI 요약 내용...")
         ));
         given(watchlistUseCase.getItems(1L, 10L)).willReturn(response);
 
@@ -137,10 +190,11 @@ class WatchlistControllerTest extends RestDocsSupport {
                                 .requestHeaders(headerWithName("Authorization").description("Bearer Access Token"))
                                 .responseFields(
                                         fieldWithPath("groupName").description("그룹 이름"),
-                                        fieldWithPath("items[].isinCode").description("ISIN 코드"),
+                                        fieldWithPath("items[].ticker").description("종목 티커"),
                                         fieldWithPath("items[].name").description("종목명"),
                                         fieldWithPath("items[].currentPrice").description("현재가"),
                                         fieldWithPath("items[].fluctuationRate").description("등락률"),
+                                        fieldWithPath("items[].note").description("투자 메모"),
                                         fieldWithPath("items[].rsi").description("RSI 지표"),
                                         fieldWithPath("items[].rsiStatus").description("RSI 상태"),
                                         fieldWithPath("items[].aiInsight").description("AI 한줄 분석")

--- a/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/watchlist/WatchlistAdapter.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/watchlist/WatchlistAdapter.java
@@ -59,7 +59,7 @@ public class WatchlistAdapter implements WatchlistPort {
     }
 
     @Override
-    public Optional<WatchlistItem> findItemByGroupAndStock(WatchlistGroup group, String isinCode) {
-        return watchlistItemRepository.findByGroupAndStockTickerAndDeletedAtIsNull(group, isinCode);
+    public Optional<WatchlistItem> findItemByGroupAndStock(WatchlistGroup group, String ticker) {
+        return watchlistItemRepository.findByGroupAndTickerAndDeletedAtIsNull(group, ticker);
     }
 }

--- a/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/watchlist/WatchlistItemRepository.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/watchlist/WatchlistItemRepository.java
@@ -12,5 +12,5 @@ public interface WatchlistItemRepository extends JpaRepository<WatchlistItem, Lo
     List<WatchlistItem> findAllByGroupAndDeletedAtIsNull(WatchlistGroup group);
     long countByGroupAndDeletedAtIsNull(WatchlistGroup group);
     boolean existsByGroupAndStockAndDeletedAtIsNull(WatchlistGroup group, Stock stock);
-    Optional<WatchlistItem> findByGroupAndStockTickerAndDeletedAtIsNull(WatchlistGroup group, String isinCode);
+    Optional<WatchlistItem> findByGroupAndTickerAndDeletedAtIsNull(WatchlistGroup group, String ticker);
 }

--- a/stockwellness-core/src/main/java/org/stockwellness/application/port/in/watchlist/WatchlistUseCase.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/port/in/watchlist/WatchlistUseCase.java
@@ -13,7 +13,8 @@ public interface WatchlistUseCase {
     void deleteGroup(Long memberId, Long groupId);
     List<WatchlistGroupResponse> getGroups(Long memberId);
 
-    void addItem(Long memberId, Long groupId, String isinCode);
-    void removeItem(Long memberId, Long groupId, String isinCode);
+    void addItem(Long memberId, Long groupId, String ticker, String note);
+    void removeItem(Long memberId, Long groupId, String ticker);
+    void updateItemNote(Long memberId, Long groupId, String ticker, String note);
     WatchlistItemListResponse getItems(Long memberId, Long groupId);
 }

--- a/stockwellness-core/src/main/java/org/stockwellness/application/port/in/watchlist/dto/WatchlistItemListResponse.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/port/in/watchlist/dto/WatchlistItemListResponse.java
@@ -11,10 +11,11 @@ public record WatchlistItemListResponse(
         List<WatchlistItemDetail> items
 ) {
     public record WatchlistItemDetail(
-            String isinCode,
+            String ticker,
             String name,
             BigDecimal currentPrice,
             BigDecimal fluctuationRate,
+            String note,
             BigDecimal rsi,
             String rsiStatus,
             String aiInsight
@@ -22,16 +23,17 @@ public record WatchlistItemListResponse(
         public static WatchlistItemDetail of(WatchlistItem item, StockDataPort.StockWellnessDetail detail) {
             if (detail == null) {
                 return new WatchlistItemDetail(
-                        item.getStock().getStandardCode(),
+                        item.getTicker(),
                         item.getStock().getName(),
-                        null, null, null, "데이터 없음", "데이터가 부족하여 AI 분석을 제공할 수 없습니다."
+                        null, null, item.getNote(), null, "데이터 없음", "데이터가 부족하여 AI 분석을 제공할 수 없습니다."
                 );
             }
             return new WatchlistItemDetail(
-                    item.getStock().getStandardCode(),
+                    item.getTicker(),
                     item.getStock().getName(),
                     detail.currentPrice(),
                     detail.fluctuationRate(),
+                    item.getNote(),
                     detail.rsi(),
                     detail.rsiStatus(),
                     detail.aiInsight()

--- a/stockwellness-core/src/main/java/org/stockwellness/application/port/out/watchlist/WatchlistPort.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/port/out/watchlist/WatchlistPort.java
@@ -24,5 +24,5 @@ public interface WatchlistPort {
 
     WatchlistGroup saveGroup(WatchlistGroup group);
 
-    Optional<WatchlistItem> findItemByGroupAndStock(WatchlistGroup group, String isinCode);
+    Optional<WatchlistItem> findItemByGroupAndStock(WatchlistGroup group, String ticker);
 }

--- a/stockwellness-core/src/main/java/org/stockwellness/application/service/watchlist/WatchlistService.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/service/watchlist/WatchlistService.java
@@ -75,18 +75,24 @@ public class WatchlistService implements WatchlistUseCase {
     }
 
     @Override
-    public void addItem(Long memberId, Long groupId, String isinCode) {
+    public void addItem(Long memberId, Long groupId, String ticker, String note) {
         WatchlistGroup group = getGroupAndCheckOwnership(memberId, groupId);
-        Stock stock = stockPort.loadStockByTicker(isinCode)
-                .orElseThrow(() -> new GlobalException(ErrorCode.RESOURCE_NOT_FOUND));
+        Stock stock = stockPort.loadStockByTicker(ticker)
+                .orElseThrow(() -> new GlobalException(ErrorCode.STOCK_NOT_FOUND));
 
-        group.addItem(stock);
+        group.addItem(stock, note);
     }
 
     @Override
-    public void removeItem(Long memberId, Long groupId, String isinCode) {
+    public void removeItem(Long memberId, Long groupId, String ticker) {
         WatchlistGroup group = getGroupAndCheckOwnership(memberId, groupId);
-        group.removeItem(isinCode);
+        group.removeItem(ticker);
+    }
+
+    @Override
+    public void updateItemNote(Long memberId, Long groupId, String ticker, String note) {
+        WatchlistGroup group = getGroupAndCheckOwnership(memberId, groupId);
+        group.updateItemNote(ticker, note);
     }
 
     @Override

--- a/stockwellness-core/src/main/java/org/stockwellness/domain/watchlist/WatchlistGroup.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/domain/watchlist/WatchlistGroup.java
@@ -70,21 +70,33 @@ public class WatchlistGroup extends AbstractEntity {
     }
 
     public void addItem(Stock stock) {
+        addItem(stock, null);
+    }
+
+    public void addItem(Stock stock, String note) {
         validateItemLimit();
         validateDuplicateItem(stock);
-        
-        WatchlistItem item = WatchlistItem.create(this, stock);
+
+        WatchlistItem item = WatchlistItem.create(this, stock, note);
         this.items.add(item);
     }
-    
-    public void removeItem(String isinCode) {
-        WatchlistItem itemToRemove = this.items.stream()
-                .filter(item -> item.getStock().getStandardCode().equals(isinCode) && item.getDeletedAt() == null)
-                .findFirst()
-                .orElseThrow(() -> new GlobalException(ErrorCode.RESOURCE_NOT_FOUND));
-        
+
+    public void updateItemNote(String ticker, String newNote) {
+        WatchlistItem item = findItemByTicker(ticker);
+        item.updateNote(newNote);
+    }
+
+    public void removeItem(String ticker) {
+        WatchlistItem itemToRemove = findItemByTicker(ticker);
         itemToRemove.delete();
         this.items.remove(itemToRemove);
+    }
+
+    private WatchlistItem findItemByTicker(String ticker) {
+        return this.items.stream()
+                .filter(item -> item.getTicker().equals(ticker) && item.getDeletedAt() == null)
+                .findFirst()
+                .orElseThrow(() -> new GlobalException(ErrorCode.RESOURCE_NOT_FOUND));
     }
 
     private void validateItemLimit() {
@@ -98,7 +110,7 @@ public class WatchlistGroup extends AbstractEntity {
 
     private void validateDuplicateItem(Stock stock) {
         boolean isDuplicate = this.items.stream()
-                .anyMatch(item -> item.getStock().getStandardCode().equals(stock.getStandardCode()) && item.getDeletedAt() == null);
+                .anyMatch(item -> item.getTicker().equals(stock.getTicker()) && item.getDeletedAt() == null);
         if (isDuplicate) {
             throw new GlobalException(ErrorCode.DUPLICATE_WATCHLIST_ITEM);
         }

--- a/stockwellness-core/src/main/java/org/stockwellness/domain/watchlist/WatchlistItem.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/domain/watchlist/WatchlistItem.java
@@ -13,6 +13,8 @@ import lombok.ToString;
 import org.stockwellness.domain.shared.AbstractEntity;
 import org.stockwellness.domain.stock.MarketType;
 import org.stockwellness.domain.stock.Stock;
+import org.stockwellness.global.error.ErrorCode;
+import org.stockwellness.global.error.exception.GlobalException;
 
 import java.time.LocalDateTime;
 
@@ -32,20 +34,44 @@ public class WatchlistItem extends AbstractEntity {
     @JoinColumn(name = "stock_id", nullable = false)
     private Stock stock;
 
+    @Column(nullable = false, length = 20)
+    private String ticker;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private MarketType marketType;
 
+    @Column(length = 200)
+    private String note;
+
     private LocalDateTime deletedAt;
 
-    private WatchlistItem(WatchlistGroup group, Stock stock) {
+    private WatchlistItem(WatchlistGroup group, Stock stock, String note) {
+        validateNote(note);
         this.group = group;
         this.stock = stock;
+        this.ticker = stock.getTicker();
         this.marketType = stock.getMarketType();
+        this.note = note;
     }
 
     public static WatchlistItem create(WatchlistGroup group, Stock stock) {
-        return new WatchlistItem(group, stock);
+        return new WatchlistItem(group, stock, null);
+    }
+
+    public static WatchlistItem create(WatchlistGroup group, Stock stock, String note) {
+        return new WatchlistItem(group, stock, note);
+    }
+
+    public void updateNote(String newNote) {
+        validateNote(newNote);
+        this.note = newNote;
+    }
+
+    private void validateNote(String note) {
+        if (note != null && note.length() > 200) {
+            throw new GlobalException(ErrorCode.WATCHLIST_NOTE_LIMIT_EXCEEDED);
+        }
     }
 
     public void delete() {

--- a/stockwellness-core/src/main/java/org/stockwellness/global/error/ErrorCode.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/global/error/ErrorCode.java
@@ -5,18 +5,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.*;
-import static org.springframework.http.HttpStatus.CONFLICT;
 
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    // 공통
+    // 공통 (G)
     INVALID_INPUT_VALUE(BAD_REQUEST, "G001", "잘못된 입력값입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "G002", "지원하지 않는 HTTP 메서드입니다."),
     RESOURCE_NOT_FOUND(NOT_FOUND, "G003", "요청한 리소스를 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G004", "서버 내부 오류가 발생했습니다."),
 
-    // 인증/인가
+    // 인증/인가 (A)
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
     EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다."),
@@ -24,34 +23,35 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "A005", "리프레시 토큰이 유효하지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "A006", "리프레시 토큰을 찾을 수 없습니다."),
 
-    // 회원
+    // 회원 (M)
     MEMBER_NOT_FOUND(NOT_FOUND, "M001", "회원을 찾을 수 없습니다."),
     DUPLICATE_EMAIL(CONFLICT, "M002", "이미 사용 중인 이메일입니다."),
     DUPLICATE_NICKNAME(CONFLICT, "M003", "이미 사용 중인 닉네임입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "M004", "비밀번호가 일치하지 않습니다."),
 
-    //포트폴리오
+    // 포트폴리오 (P)
     INVALID_PORTFOLIO_TOTAL_PIECE(BAD_REQUEST, "P001", "포트폴리오 총 조각 수는 1개 이상, 8개 이하여야 합니다."),
     INVALID_ITEM_PIECE_COUNT(BAD_REQUEST, "P002", "각 종목은 최소 1조각 이상이어야 합니다."),
     DUPLICATE_PORTFOLIO_NAME(CONFLICT, "P003", "이미 사용 중인 포트폴리오 이름입니다."),
     PORTFOLIO_NOT_FOUND(NOT_FOUND, "P004", "포트폴리오를 찾을 수 없습니다."),
 
-    // 관심 종목 (Watchlist)
+    // 관심 종목 (W)
     WATCHLIST_GROUP_LIMIT_EXCEEDED(BAD_REQUEST, "W001", "관심 그룹은 최대 10개까지 생성할 수 있습니다."),
     WATCHLIST_ITEM_LIMIT_EXCEEDED(BAD_REQUEST, "W002", "관심 종목은 한 그룹당 최대 50개까지 추가할 수 있습니다."),
     DUPLICATE_WATCHLIST_ITEM(CONFLICT, "W003", "이미 그룹에 등록된 종목입니다."),
+    WATCHLIST_NOTE_LIMIT_EXCEEDED(BAD_REQUEST, "W004", "메모는 최대 200자까지 입력할 수 있습니다."),
 
-    // 주식
+    // 주식 (S)
     STOCK_NOT_FOUND(NOT_FOUND, "S001", "종목을 찾을 수 없습니다."),
     PRICE_DATA_NOT_FOUND(NOT_FOUND, "S002", "해당 기간의 시세 데이터를 찾을 수 없습니다."),
 
-    // 섹터 (Sector)
-    SECTOR_NOT_FOUND(NOT_FOUND, "S101", "섹터를 찾을 수 없습니다."),
-    SECTOR_DATA_NOT_FOUND(NOT_FOUND, "S102", "섹터 상세 정보를 찾을 수 없습니다."),
-    SECTOR_HISTORY_NOT_FOUND(NOT_FOUND, "S103", "섹터 이력 데이터를 찾을 수 없습니다."),
-    SECTOR_SYNC_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S104", "섹터 데이터 동기화 중 오류가 발생했습니다."),
+    // 섹터 (T)
+    SECTOR_NOT_FOUND(NOT_FOUND, "T001", "섹터를 찾을 수 없습니다."),
+    SECTOR_DATA_NOT_FOUND(NOT_FOUND, "T002", "섹터 상세 정보를 찾을 수 없습니다."),
+    SECTOR_HISTORY_NOT_FOUND(NOT_FOUND, "T003", "섹터 이력 데이터를 찾을 수 없습니다."),
+    SECTOR_SYNC_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "T004", "섹터 데이터 동기화 중 오류가 발생했습니다."),
 
-    // 배치 (Batch)
+    // 배치 (B)
     BATCH_STEP_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "B001", "배치 작업이 중단되었습니다."),
     RATE_LIMIT_WAIT_CANCELLED(HttpStatus.INTERNAL_SERVER_ERROR, "B002", "RateLimiter 대기 중 취소되었습니다."),
     BATCH_EXECUTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "B003", "배치 실행 중 오류가 발생했습니다."),

--- a/stockwellness-core/src/main/java/org/stockwellness/global/error/exception/BusinessException.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/global/error/exception/BusinessException.java
@@ -1,7 +1,6 @@
 package org.stockwellness.global.error.exception;
 
 import lombok.Getter;
-import org.springframework.http.ProblemDetail;
 import org.stockwellness.global.error.ErrorCode;
 
 @Getter

--- a/stockwellness-core/src/test/java/org/stockwellness/domain/watchlist/WatchlistGroupTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/domain/watchlist/WatchlistGroupTest.java
@@ -1,132 +1,149 @@
-//package org.stockwellness.domain.watchlist;
-//
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.stockwellness.domain.member.LoginType;
-//import org.stockwellness.domain.member.Member;
-//import org.stockwellness.domain.stock.MarketType;
-//import org.stockwellness.domain.stock.Stock;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.assertj.core.api.Assertions.assertThatThrownBy;
-//
-//class WatchlistGroupTest {
-//
-//    @Test
-//    @DisplayName("관심 종목 그룹을 생성한다")
-//    void createWatchlistGroup() {
-//        // given
-//        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
-//        String name = "내 관심 그룹";
-//
-//        // when
-//        WatchlistGroup group = WatchlistGroup.create(member, name);
-//
-//        // then
-//        assertThat(group.getMember()).isEqualTo(member);
-//        assertThat(group.getName()).isEqualTo(name);
-//        assertThat(group.getDeletedAt()).isNull();
-//        assertThat(group.getItems()).isEmpty();
-//    }
-//
-//    @Test
-//    @DisplayName("그룹 이름을 변경한다")
-//    void renameWatchlistGroup() {
-//        // given
-//        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
-//        WatchlistGroup group = WatchlistGroup.create(member, "기존 이름");
-//        String newName = "새 이름";
-//
-//        // when
-//        group.rename(newName);
-//
-//        // then
-//        assertThat(group.getName()).isEqualTo(newName);
-//    }
-//
-//    @Test
-//    @DisplayName("그룹을 삭제하면 아이템도 Soft Delete 된다")
-//    void deleteWatchlistGroup() {
-//        // given
-//        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
-//        WatchlistGroup group = WatchlistGroup.create(member, "삭제할 그룹");
-//        Stock stock = Stock.of("KR7005930003", "Samsung", "005930", MarketType.KOSPI, 100L, "123", "Corp");
-//        group.addItem(stock);
-//        WatchlistItem item = group.getItems().get(0);
-//
-//        // when
-//        group.delete();
-//
-//        // then
-//        assertThat(group.getDeletedAt()).isNotNull();
-//        assertThat(item.getDeletedAt()).isNotNull();
-//        assertThat(group.getItems()).isEmpty();
-//    }
-//
-//    @Test
-//    @DisplayName("그룹에 종목을 추가한다")
-//    void addItem() {
-//        // given
-//        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
-//        WatchlistGroup group = WatchlistGroup.create(member, "그룹");
-//        Stock stock = Stock.of("KR7005930003", "Samsung", "005930", MarketType.KOSPI, 100L, "123", "Corp");
-//
-//        // when
-//        group.addItem(stock);
-//
-//        // then
-//        assertThat(group.getItems()).hasSize(1);
-//        assertThat(group.getItems().get(0).getStock()).isEqualTo(stock);
-//    }
-//
-//    @Test
-//    @DisplayName("그룹 내 중복된 종목을 추가할 수 없다")
-//    void addItemDuplicate() {
-//        // given
-//        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
-//        WatchlistGroup group = WatchlistGroup.create(member, "그룹");
-//        Stock stock = Stock.of("KR7005930003", "Samsung", "005930", MarketType.KOSPI, 100L, "123", "Corp");
-//        group.addItem(stock);
-//
-//        // when & then
-//        assertThatThrownBy(() -> group.addItem(stock))
-//                .isInstanceOf(org.stockwellness.global.error.exception.BusinessException.class)
-//                .hasMessage("이미 그룹에 등록된 종목입니다.");
-//    }
-//
-//    @Test
-//    @DisplayName("그룹에서 종목을 제거한다")
-//    void removeItem() {
-//        // given
-//        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
-//        WatchlistGroup group = WatchlistGroup.create(member, "그룹");
-//        Stock stock = Stock.of("KR7005930003", "Samsung", "005930", MarketType.KOSPI, 100L, "123", "Corp");
-//        group.addItem(stock);
-//
-//        // when
-//        group.removeItem(stock.getStandardCode());
-//
-//        // then
-//        assertThat(group.getItems()).isEmpty();
-//    }
-//
-//    @Test
-//    @DisplayName("그룹 내 아이템은 최대 50개까지만 추가할 수 있다")
-//    void addItemLimit() {
-//        // given
-//        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
-//        WatchlistGroup group = WatchlistGroup.create(member, "그룹");
-//
-//        // 50개 채우기
-//        for (int i = 0; i < 50; i++) {
-//            Stock stock = Stock.of("STOCK" + i, "Stock" + i, "000" + i, MarketType.KOSPI, 100L, "123", "Corp");
-//            group.addItem(stock);
-//        }
-//
-//        // when & then
-//        Stock newStock = Stock.of("NEW", "New", "999", MarketType.KOSPI, 100L, "123", "Corp");
-//        assertThatThrownBy(() -> group.addItem(newStock))
-//                .isInstanceOf(org.stockwellness.global.error.exception.BusinessException.class)
-//                .hasMessage("관심 종목은 한 그룹당 최대 50개까지 추가할 수 있습니다.");
-//    }
-//}
+package org.stockwellness.domain.watchlist;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.stockwellness.domain.member.LoginType;
+import org.stockwellness.domain.member.Member;
+import org.stockwellness.domain.stock.*;
+import org.stockwellness.global.error.ErrorCode;
+import org.stockwellness.global.error.exception.BusinessException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WatchlistGroupTest {
+
+    @Test
+    @DisplayName("관심 종목 그룹을 생성한다")
+    void createWatchlistGroup() {
+        // given
+        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
+        String name = "내 관심 그룹";
+
+        // when
+        WatchlistGroup group = WatchlistGroup.create(member, name);
+
+        // then
+        assertThat(group.getMember()).isEqualTo(member);
+        assertThat(group.getName()).isEqualTo(name);
+        assertThat(group.getDeletedAt()).isNull();
+        assertThat(group.getItems()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("그룹 이름을 변경한다")
+    void renameWatchlistGroup() {
+        // given
+        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "기존 이름");
+        String newName = "새 이름";
+
+        // when
+        group.rename(newName);
+
+        // then
+        assertThat(group.getName()).isEqualTo(newName);
+    }
+
+    @Test
+    @DisplayName("그룹을 삭제하면 아이템도 Soft Delete 된다")
+    void deleteWatchlistGroup() {
+        // given
+        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "삭제할 그룹");
+        Stock stock = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+        group.addItem(stock);
+        WatchlistItem item = group.getItems().get(0);
+
+        // when
+        group.delete();
+
+        // then
+        assertThat(group.getDeletedAt()).isNotNull();
+        assertThat(item.getDeletedAt()).isNotNull();
+        assertThat(group.getItems()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("그룹에 종목을 추가한다")
+    void addItem() {
+        // given
+        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "그룹");
+        Stock stock = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+
+        // when
+        group.addItem(stock, "메모");
+
+        // then
+        assertThat(group.getItems()).hasSize(1);
+        assertThat(group.getItems().get(0).getStock()).isEqualTo(stock);
+        assertThat(group.getItems().get(0).getNote()).isEqualTo("메모");
+    }
+
+    @Test
+    @DisplayName("그룹 내 중복된 종목을 추가할 수 없다 (티커 기준)")
+    void addItemDuplicate() {
+        // given
+        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "그룹");
+        Stock stock = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+        group.addItem(stock);
+
+        // when & then
+        assertThatThrownBy(() -> group.addItem(stock))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.DUPLICATE_WATCHLIST_ITEM.getMessage());
+    }
+
+    @Test
+    @DisplayName("그룹에서 종목의 메모를 수정한다")
+    void updateItemNote() {
+        // given
+        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "그룹");
+        Stock stock = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+        group.addItem(stock, "기존 메모");
+
+        // when
+        group.updateItemNote("005930", "수정 메모");
+
+        // then
+        assertThat(group.getItems().get(0).getNote()).isEqualTo("수정 메모");
+    }
+
+    @Test
+    @DisplayName("그룹에서 종목을 제거한다 (티커 기준)")
+    void removeItem() {
+        // given
+        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "그룹");
+        Stock stock = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+        group.addItem(stock);
+
+        // when
+        group.removeItem("005930");
+
+        // then
+        assertThat(group.getItems()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("그룹 내 아이템은 최대 50개까지만 추가할 수 있다")
+    void addItemLimit() {
+        // given
+        Member member = Member.register("test@email.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "그룹");
+
+        for (int i = 0; i < 50; i++) {
+            Stock stock = Stock.of("TICKER" + i, "ISIN" + i, "Stock" + i, MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+            group.addItem(stock);
+        }
+
+        // when & then
+        Stock newStock = Stock.of("NEW", "NEW_ISIN", "New", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+        assertThatThrownBy(() -> group.addItem(newStock))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.WATCHLIST_ITEM_LIMIT_EXCEEDED.getMessage());
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/domain/watchlist/WatchlistItemTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/domain/watchlist/WatchlistItemTest.java
@@ -1,50 +1,85 @@
-//package org.stockwellness.domain.watchlist;
-//
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.stockwellness.domain.member.LoginType;
-//import org.stockwellness.domain.member.Member;
-//import org.stockwellness.domain.stock.MarketType;
-//import org.stockwellness.domain.stock.Stock;
-//
-//import java.time.LocalDateTime;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//
-//class WatchlistItemTest {
-//
-//    @Test
-//    @DisplayName("관심 종목 아이템을 생성한다")
-//    void createWatchlistItem() {
-//        // given
-//        Member member = Member.register("test@test.com", "tester", LoginType.KAKAO);
-//        WatchlistGroup group = WatchlistGroup.create(member, "그룹1");
-//        Stock stock = Stock.of("KR7005930003", "삼성전자", "005930", MarketType.KOSPI, 1000L, "1234", "삼성");
-//
-//        // when
-//        WatchlistItem item = WatchlistItem.create(group, stock);
-//
-//        // then
-//        assertThat(item.getGroup()).isEqualTo(group);
-//        assertThat(item.getStock()).isEqualTo(stock);
-//        assertThat(item.getMarketType()).isEqualTo(MarketType.KOSPI); // Stock에서 가져옴
-//        assertThat(item.getDeletedAt()).isNull();
-//    }
-//
-//    @Test
-//    @DisplayName("아이템 삭제 시 deletedAt이 설정된다")
-//    void deleteWatchlistItem() {
-//        // given
-//        Member member = Member.register("test@test.com", "tester", LoginType.KAKAO);
-//        WatchlistGroup group = WatchlistGroup.create(member, "그룹1");
-//        Stock stock = Stock.of("KR7005930003", "삼성전자", "005930", MarketType.KOSPI, 1000L, "1234", "삼성");
-//        WatchlistItem item = WatchlistItem.create(group, stock);
-//
-//        // when
-//        item.delete();
-//
-//        // then
-//        assertThat(item.getDeletedAt()).isNotNull();
-//        assertThat(item.getDeletedAt()).isBeforeOrEqualTo(LocalDateTime.now());
-//    }
-//}
+package org.stockwellness.domain.watchlist;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.stockwellness.domain.member.LoginType;
+import org.stockwellness.domain.member.Member;
+import org.stockwellness.domain.stock.*;
+import org.stockwellness.global.error.ErrorCode;
+import org.stockwellness.global.error.exception.BusinessException;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WatchlistItemTest {
+
+    @Test
+    @DisplayName("관심 종목 아이템을 생성한다")
+    void createWatchlistItem() {
+        // given
+        Member member = Member.register("test@test.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "그룹1");
+        Stock stock = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+
+        // when
+        WatchlistItem item = WatchlistItem.create(group, stock, "메모");
+
+        // then
+        assertThat(item.getGroup()).isEqualTo(group);
+        assertThat(item.getStock()).isEqualTo(stock);
+        assertThat(item.getTicker()).isEqualTo("005930");
+        assertThat(item.getMarketType()).isEqualTo(MarketType.KOSPI);
+        assertThat(item.getNote()).isEqualTo("메모");
+        assertThat(item.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("아이템 삭제 시 deletedAt이 설정된다")
+    void deleteWatchlistItem() {
+        // given
+        Member member = Member.register("test@test.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "그룹1");
+        Stock stock = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+        WatchlistItem item = WatchlistItem.create(group, stock);
+
+        // when
+        item.delete();
+
+        // then
+        assertThat(item.getDeletedAt()).isNotNull();
+        assertThat(item.getDeletedAt()).isBeforeOrEqualTo(LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("메모를 수정한다")
+    void updateNote() {
+        // given
+        Member member = Member.register("test@test.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "그룹1");
+        Stock stock = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+        WatchlistItem item = WatchlistItem.create(group, stock, "기존 메모");
+
+        // when
+        item.updateNote("수정된 메모");
+
+        // then
+        assertThat(item.getNote()).isEqualTo("수정된 메모");
+    }
+
+    @Test
+    @DisplayName("메모는 200자를 초과할 수 없다")
+    void validateNoteLength() {
+        // given
+        Member member = Member.register("test@test.com", "tester", LoginType.KAKAO);
+        WatchlistGroup group = WatchlistGroup.create(member, "그룹1");
+        Stock stock = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+        String longNote = "A".repeat(201);
+
+        // when & then
+        assertThatThrownBy(() -> WatchlistItem.create(group, stock, longNote))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.WATCHLIST_NOTE_LIMIT_EXCEEDED.getMessage());
+    }
+}


### PR DESCRIPTION
## 개요
웰니스 관심 종목 기능을 티커 중심 식별 체계로 개편하고, 투자 메모 관리 기능을 추가했습니다.

## 주요 변경 사항
- WatchlistItem에 티커 기반 식별 및 투자 메모 필드 추가
- 관심 종목 관리 API 경로와 요청 DTO 개편
- 메모 수정 요청 DTO 및 서비스 로직 추가
- Watchlist 저장소/포트/서비스 계층을 티커 중심으로 정리
- OpenAPI 명세 및 Controller 테스트 갱신

## 검증
- WatchlistControllerTest 보강
- WatchlistGroupTest, WatchlistItemTest 업데이트

## 관련 이슈
- Related #100
