### PR TITLE
feat(member,market): 알림 설정 API 및 시장 인덱스 API 구현

### DIFF
--- a/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/market/MarketController.java
+++ b/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/market/MarketController.java
@@ -1,0 +1,27 @@
+package org.stockwellness.adapter.in.web.market;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.stockwellness.application.port.in.stock.MarketIndexUseCase;
+import org.stockwellness.application.port.in.stock.result.MarketIndexResult;
+import org.stockwellness.global.common.response.ApiResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/market")
+@RequiredArgsConstructor
+public class MarketController {
+
+    private final MarketIndexUseCase marketIndexUseCase;
+
+    /**
+     * 시장 지수 목록 조회 (KOSPI · KOSDAQ · S&P500)
+     */
+    @GetMapping("/indexes")
+    public ApiResponse<List<MarketIndexResult>> getMarketIndexes() {
+        return ApiResponse.success(marketIndexUseCase.getMarketIndexes());
+    }
+}

--- a/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/member/MemberController.java
+++ b/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/member/MemberController.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.stockwellness.adapter.in.web.member.dto.UpdateMemberRequest;
+import org.stockwellness.adapter.in.web.member.dto.UpdateNotificationRequest;
 import org.stockwellness.application.port.in.member.MemberUseCase;
 import org.stockwellness.application.port.in.member.result.MemberResult;
+import org.stockwellness.application.port.in.member.result.NotificationSettingsResult;
 import org.stockwellness.global.common.response.ApiResponse;
 import org.stockwellness.global.security.MemberPrincipal;
 
@@ -44,6 +46,26 @@ public class MemberController {
     @DeleteMapping("/me")
     public ApiResponse<Void> deactivateMember(@AuthenticationPrincipal MemberPrincipal memberPrincipal) {
         memberUseCase.withdrawMember(memberPrincipal.id());
+        return ApiResponse.success();
+    }
+
+    /**
+     * 알림 설정 조회
+     */
+    @GetMapping("/me/notifications")
+    public ApiResponse<NotificationSettingsResult> getNotificationSettings(
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal) {
+        return ApiResponse.success(memberUseCase.getNotificationSettings(memberPrincipal.id()));
+    }
+
+    /**
+     * 알림 설정 변경
+     */
+    @PutMapping("/me/notifications")
+    public ApiResponse<Void> updateNotificationSettings(
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+            @RequestBody UpdateNotificationRequest request) {
+        memberUseCase.updateNotificationSettings(memberPrincipal.id(), request.toCommand(memberPrincipal.id()));
         return ApiResponse.success();
     }
 }

--- a/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/member/dto/UpdateNotificationRequest.java
+++ b/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/member/dto/UpdateNotificationRequest.java
@@ -1,0 +1,13 @@
+package org.stockwellness.adapter.in.web.member.dto;
+
+import org.stockwellness.application.port.in.member.command.UpdateNotificationCommand;
+
+public record UpdateNotificationRequest(
+        Boolean rebalancing,
+        Boolean marketAlert,
+        Boolean newListing
+) {
+    public UpdateNotificationCommand toCommand(Long memberId) {
+        return new UpdateNotificationCommand(memberId, rebalancing, marketAlert, newListing);
+    }
+}

--- a/stockwellness-core/src/main/java/org/stockwellness/application/port/in/member/MemberUseCase.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/port/in/member/MemberUseCase.java
@@ -1,7 +1,9 @@
 package org.stockwellness.application.port.in.member;
 
 import org.stockwellness.application.port.in.member.command.UpdateMemberCommand;
+import org.stockwellness.application.port.in.member.command.UpdateNotificationCommand;
 import org.stockwellness.application.port.in.member.result.MemberResult;
+import org.stockwellness.application.port.in.member.result.NotificationSettingsResult;
 
 public interface MemberUseCase {
     MemberResult getMember(Long memberId);
@@ -9,4 +11,8 @@ public interface MemberUseCase {
     void updateMember(Long memberId, UpdateMemberCommand command);
 
     void withdrawMember(Long memberId);
+
+    NotificationSettingsResult getNotificationSettings(Long memberId);
+
+    void updateNotificationSettings(Long memberId, UpdateNotificationCommand command);
 }

--- a/stockwellness-core/src/main/java/org/stockwellness/application/port/in/member/command/UpdateNotificationCommand.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/port/in/member/command/UpdateNotificationCommand.java
@@ -1,0 +1,8 @@
+package org.stockwellness.application.port.in.member.command;
+
+public record UpdateNotificationCommand(
+        Long memberId,
+        Boolean rebalancing,
+        Boolean marketAlert,
+        Boolean newListing
+) {}

--- a/stockwellness-core/src/main/java/org/stockwellness/application/port/in/member/result/NotificationSettingsResult.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/port/in/member/result/NotificationSettingsResult.java
@@ -1,0 +1,17 @@
+package org.stockwellness.application.port.in.member.result;
+
+import org.stockwellness.domain.member.Member;
+
+public record NotificationSettingsResult(
+        boolean rebalancing,
+        boolean marketAlert,
+        boolean newListing
+) {
+    public static NotificationSettingsResult from(Member member) {
+        return new NotificationSettingsResult(
+                member.isNotificationRebalancing(),
+                member.isNotificationMarketAlert(),
+                member.isNotificationNewListing()
+        );
+    }
+}

--- a/stockwellness-core/src/main/java/org/stockwellness/application/port/in/stock/MarketIndexUseCase.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/port/in/stock/MarketIndexUseCase.java
@@ -1,0 +1,9 @@
+package org.stockwellness.application.port.in.stock;
+
+import org.stockwellness.application.port.in.stock.result.MarketIndexResult;
+
+import java.util.List;
+
+public interface MarketIndexUseCase {
+    List<MarketIndexResult> getMarketIndexes();
+}

--- a/stockwellness-core/src/main/java/org/stockwellness/application/port/in/stock/result/MarketIndexResult.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/port/in/stock/result/MarketIndexResult.java
@@ -1,0 +1,17 @@
+package org.stockwellness.application.port.in.stock.result;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public record MarketIndexResult(
+        String name,
+        BigDecimal currentPrice,
+        BigDecimal fluctuationRate,
+        List<HistoryPoint> history
+) {
+    public record HistoryPoint(
+            LocalDate date,
+            BigDecimal close
+    ) {}
+}

--- a/stockwellness-core/src/main/java/org/stockwellness/application/service/member/MemberService.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/service/member/MemberService.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.stockwellness.application.port.in.member.MemberUseCase;
 import org.stockwellness.application.port.in.member.command.UpdateMemberCommand;
+import org.stockwellness.application.port.in.member.command.UpdateNotificationCommand;
 import org.stockwellness.application.port.in.member.result.MemberResult;
+import org.stockwellness.application.port.in.member.result.NotificationSettingsResult;
 import org.stockwellness.application.port.out.member.LoadMemberPort;
 import org.stockwellness.domain.member.Member;
 import org.stockwellness.domain.member.exception.MemberNotFoundException;
@@ -49,6 +51,21 @@ public class MemberService implements MemberUseCase {
     public void withdrawMember(Long memberId) {
         var member = findMember(memberId);
         member.deactivate();
+    }
+
+    @Override
+    public NotificationSettingsResult getNotificationSettings(Long memberId) {
+        var member = findMember(memberId);
+        return NotificationSettingsResult.from(member);
+    }
+
+    @Override
+    public void updateNotificationSettings(Long memberId, UpdateNotificationCommand command) {
+        var member = findMember(memberId);
+        if (!member.isActive()) {
+            throw new GlobalException(UNAUTHORIZED);
+        }
+        member.updateNotifications(command.rebalancing(), command.marketAlert(), command.newListing());
     }
 
     private Member findMember(Long memberId) {

--- a/stockwellness-core/src/main/java/org/stockwellness/application/service/stock/MarketIndexService.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/service/stock/MarketIndexService.java
@@ -1,0 +1,87 @@
+package org.stockwellness.application.service.stock;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.stockwellness.application.port.in.stock.MarketIndexUseCase;
+import org.stockwellness.application.port.in.stock.result.MarketIndexResult;
+import org.stockwellness.application.port.in.stock.result.MarketIndexResult.HistoryPoint;
+import org.stockwellness.application.port.in.stock.result.StockPriceResult;
+import org.stockwellness.application.port.out.stock.LoadBenchmarkPort;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MarketIndexService implements MarketIndexUseCase {
+
+    private final LoadBenchmarkPort loadBenchmarkPort;
+
+    private static final int HISTORY_DAYS = 30;
+    private static final int DISPLAY_SCALE = 2;
+
+    private record IndexDef(String name, String ticker) {}
+
+    private static final List<IndexDef> INDEXES = List.of(
+            new IndexDef("KOSPI", "^KS11"),
+            new IndexDef("KOSDAQ", "^KQ11"),
+            new IndexDef("S&P500", "^GSPC")
+    );
+
+    @Override
+    public List<MarketIndexResult> getMarketIndexes() {
+        LocalDate end = LocalDate.now();
+        LocalDate start = end.minusDays(HISTORY_DAYS);
+
+        List<MarketIndexResult> results = new ArrayList<>();
+        for (IndexDef index : INDEXES) {
+            try {
+                List<StockPriceResult> prices = loadBenchmarkPort.loadBenchmarkPrices(index.ticker(), start, end);
+                results.add(toResult(index.name(), prices));
+            } catch (Exception e) {
+                log.warn("시장 지수 조회 실패: {}", index.name(), e);
+                results.add(emptyResult(index.name()));
+            }
+        }
+        return results;
+    }
+
+    private MarketIndexResult toResult(String name, List<StockPriceResult> prices) {
+        if (prices.isEmpty()) {
+            return emptyResult(name);
+        }
+
+        StockPriceResult latest = prices.get(prices.size() - 1);
+        BigDecimal currentPrice = latest.closePrice();
+        BigDecimal fluctuationRate = BigDecimal.ZERO;
+
+        if (prices.size() >= 2) {
+            StockPriceResult prev = prices.get(prices.size() - 2);
+            BigDecimal prevClose = prev.closePrice();
+            if (prevClose != null && prevClose.compareTo(BigDecimal.ZERO) > 0) {
+                fluctuationRate = currentPrice.subtract(prevClose)
+                        .divide(prevClose, 4, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100))
+                        .setScale(DISPLAY_SCALE, RoundingMode.HALF_UP);
+            }
+        }
+
+        List<HistoryPoint> history = prices.stream()
+                .map(p -> new HistoryPoint(p.baseDate(), p.closePrice()))
+                .toList();
+
+        return new MarketIndexResult(name, currentPrice, fluctuationRate, history);
+    }
+
+    private MarketIndexResult emptyResult(String name) {
+        return new MarketIndexResult(name, BigDecimal.ZERO, BigDecimal.ZERO, Collections.emptyList());
+    }
+}

--- a/stockwellness-core/src/main/java/org/stockwellness/domain/member/Member.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/domain/member/Member.java
@@ -43,6 +43,15 @@ public class Member extends AbstractEntity {
     @Enumerated(STRING)
     private MemberStatus status;
 
+    @Column(nullable = false)
+    private boolean notificationRebalancing = true;
+
+    @Column(nullable = false)
+    private boolean notificationMarketAlert = false;
+
+    @Column(nullable = false)
+    private boolean notificationNewListing = false;
+
     @LastModifiedDate
     private LocalDateTime modifiedAt;
 
@@ -76,6 +85,12 @@ public class Member extends AbstractEntity {
         if (riskLevel != null) {
             this.riskLevel = riskLevel;
         }
+    }
+
+    public void updateNotifications(Boolean rebalancing, Boolean marketAlert, Boolean newListing) {
+        if (rebalancing != null) this.notificationRebalancing = rebalancing;
+        if (marketAlert != null) this.notificationMarketAlert = marketAlert;
+        if (newListing != null) this.notificationNewListing = newListing;
     }
 
     private static String validateNickname(String nickname) {


### PR DESCRIPTION
## Summary
- **#139** 회원 알림 설정 CRUD API (리밸런싱 / 시장급변 / 신규상장)
- **#140** 시장 인덱스 조회 API (KOSPI / KOSDAQ / S&P500, 30일 히스토리 포함)

## Changes

### Member 알림 설정 (#139)
- `Member` 엔티티에 `notificationRebalancing`, `notificationMarketAlert`, `notificationNewListing` boolean 컬럼 추가 (기본값 true/false/false)
- `MemberUseCase`: `getNotificationSettings()` / `updateNotificationSettings()` 추가
- `MemberService`: 조회 및 부분 업데이트(null 필드 무시) 구현
- `MemberController`: `GET/PUT /api/v1/members/me/notifications` 엔드포인트 추가
- `NotificationSettingsResult`, `UpdateNotificationCommand`, `UpdateNotificationRequest` 추가

### 시장 인덱스 (#140)
- `MarketIndexUseCase` / `MarketIndexResult` 도메인 포트 및 결과 모델 추가
- `MarketIndexService`: `LoadBenchmarkPort` (`^KS11`, `^KQ11`, `^GSPC`) 활용, 최근 30일 히스토리 + 전일 대비 등락률 계산
- `MarketController`: `GET /api/v1/market/indexes` 엔드포인트 추가 (StockController와 분리)

## Test plan
- [ ] `GET /api/v1/members/me/notifications` → 기본값 응답 확인
- [ ] `PUT /api/v1/members/me/notifications` → 부분 업데이트 후 재조회 일치 확인
- [ ] `GET /api/v1/market/indexes` → KOSPI/KOSDAQ/S&P500 3개 항목, history 배열 포함 확인
- [ ] index 중 하나 조회 실패 시 나머지 정상 응답 확인 (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)