### PR TITLE
fix(#176): SectorInsightService detail/comparison fallback 추가

### DIFF
--- a/stockwellness-core/src/main/java/org/stockwellness/application/service/stock/SectorInsightService.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/service/stock/SectorInsightService.java
@@ -77,6 +77,7 @@ public class SectorInsightService implements SectorInsightUseCase {
     @Cacheable(cacheNames = "sectorDetail", key = "#sectorCode + '_' + #date.toString()")
     public SectorDetailResult getSectorDetail(String sectorCode, LocalDate date) {
         SectorInsight insight = sectorInsightPort.findBySectorCodeAndDate(sectorCode, date)
+                .or(() -> sectorInsightPort.findLatestBefore(sectorCode, date))
                 .orElseThrow(() -> new SectorDomainException(ErrorCode.SECTOR_DATA_NOT_FOUND));
 
         return new SectorDetailResult(
@@ -92,18 +93,20 @@ public class SectorInsightService implements SectorInsightUseCase {
     @Cacheable(cacheNames = "sectorComparison", key = "#sectorCode + '_' + #date.toString()")
     public SectorComparisonResult compareWithMarket(String sectorCode, LocalDate date) {
         SectorInsight sector = sectorInsightPort.findBySectorCodeAndDate(sectorCode, date)
+                .or(() -> sectorInsightPort.findLatestBefore(sectorCode, date))
                 .orElseThrow(() -> new SectorDomainException(ErrorCode.SECTOR_DATA_NOT_FOUND));
 
+        LocalDate effectiveDate = sector.getBaseDate();
         String marketCode = (sector.getMarketType() == MarketType.KOSDAQ) ? "1001" : "0001";
-        Map<String, SectorInsight> todayData = sectorInsightPort.findByCodesAndDate(List.of(sectorCode, marketCode), date).stream()
+        Map<String, SectorInsight> todayData = sectorInsightPort.findByCodesAndDate(List.of(sectorCode, marketCode), effectiveDate).stream()
                 .collect(Collectors.toMap(SectorInsight::getSectorCode, s -> s));
 
         SectorInsight market = todayData.get(marketCode);
         if (market == null) throw new SectorDomainException(ErrorCode.SECTOR_DATA_NOT_FOUND);
 
         BigDecimal rs = sector.getAvgFluctuationRate().subtract(market.getAvgFluctuationRate());
-        List<SectorInsight> sectorHistory = sectorInsightPort.findHistoryByCode(sectorCode, date, 5);
-        List<SectorInsight> marketHistory = sectorInsightPort.findHistoryByCode(marketCode, date, 5);
+        List<SectorInsight> sectorHistory = sectorInsightPort.findHistoryByCode(sectorCode, effectiveDate, 5);
+        List<SectorInsight> marketHistory = sectorInsightPort.findHistoryByCode(marketCode, effectiveDate, 5);
         
         List<SectorComparisonResult.HistoricalRS> history = calculateHistoricalRS(sectorHistory, marketHistory);
 

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/stock/SectorInsightServiceTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/stock/SectorInsightServiceTest.java
@@ -1,0 +1,129 @@
+package org.stockwellness.application.service.stock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.stockwellness.application.port.in.stock.result.SectorComparisonResult;
+import org.stockwellness.application.port.in.stock.result.SectorDetailResult;
+import org.stockwellness.application.port.out.stock.SectorInsightPort;
+import org.stockwellness.domain.stock.MarketType;
+import org.stockwellness.domain.stock.insight.SectorInsight;
+import org.stockwellness.domain.stock.insight.SectorIndicators;
+import org.stockwellness.domain.stock.insight.exception.SectorDomainException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SectorInsightService 단위 테스트")
+class SectorInsightServiceTest {
+
+    @InjectMocks
+    private SectorInsightService sectorInsightService;
+
+    @Mock
+    private SectorInsightPort sectorInsightPort;
+
+    private SectorInsight mockInsight(String sectorCode, LocalDate date) {
+        SectorIndicators indicators = SectorIndicators.of(
+                BigDecimal.valueOf(1000), BigDecimal.valueOf(1.5),
+                100L, -50L, 0, 0
+        );
+        return SectorInsight.of("전기전자", sectorCode, MarketType.KOSPI, date, indicators, null, false);
+    }
+
+    @Nested
+    @DisplayName("getSectorDetail")
+    class GetSectorDetail {
+
+        @Test
+        @DisplayName("당일 데이터가 있으면 해당 데이터를 반환한다")
+        void returnsTodayData_whenExists() {
+            LocalDate today = LocalDate.now();
+            SectorInsight insight = mockInsight("0007", today);
+            given(sectorInsightPort.findBySectorCodeAndDate("0007", today)).willReturn(Optional.of(insight));
+
+            SectorDetailResult result = sectorInsightService.getSectorDetail("0007", today);
+
+            assertThat(result.sectorCode()).isEqualTo("0007");
+        }
+
+        @Test
+        @DisplayName("당일 데이터 없을 때 findLatestBefore 결과를 반환한다")
+        void fallsBackToLatestBefore_whenTodayDataAbsent() {
+            LocalDate today = LocalDate.now();
+            SectorInsight yesterday = mockInsight("0007", today.minusDays(1));
+            given(sectorInsightPort.findBySectorCodeAndDate("0007", today)).willReturn(Optional.empty());
+            given(sectorInsightPort.findLatestBefore("0007", today)).willReturn(Optional.of(yesterday));
+
+            SectorDetailResult result = sectorInsightService.getSectorDetail("0007", today);
+
+            assertThat(result.sectorCode()).isEqualTo("0007");
+            verify(sectorInsightPort).findLatestBefore("0007", today);
+        }
+
+        @Test
+        @DisplayName("당일 데이터도 없고 최근 데이터도 없으면 예외를 던진다")
+        void throwsException_whenNoDataExists() {
+            LocalDate today = LocalDate.now();
+            given(sectorInsightPort.findBySectorCodeAndDate("0007", today)).willReturn(Optional.empty());
+            given(sectorInsightPort.findLatestBefore("0007", today)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sectorInsightService.getSectorDetail("0007", today))
+                    .isInstanceOf(SectorDomainException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("compareWithMarket")
+    class CompareWithMarket {
+
+        @Test
+        @DisplayName("당일 데이터 없을 때 findLatestBefore 기준 날짜로 시장 비교를 수행한다")
+        void fallsBackToLatestBefore_andUsesEffectiveDate() {
+            LocalDate today = LocalDate.now();
+            LocalDate yesterday = today.minusDays(1);
+            SectorInsight sector = mockInsight("0007", yesterday);
+            SectorInsight market = mockInsight("0001", yesterday);
+
+            given(sectorInsightPort.findBySectorCodeAndDate("0007", today)).willReturn(Optional.empty());
+            given(sectorInsightPort.findLatestBefore("0007", today)).willReturn(Optional.of(sector));
+            given(sectorInsightPort.findByCodesAndDate(List.of("0007", "0001"), yesterday))
+                    .willReturn(List.of(sector, market));
+            given(sectorInsightPort.findHistoryByCode(eq("0007"), eq(yesterday), any(int.class)))
+                    .willReturn(List.of());
+            given(sectorInsightPort.findHistoryByCode(eq("0001"), eq(yesterday), any(int.class)))
+                    .willReturn(List.of());
+
+            SectorComparisonResult result = sectorInsightService.compareWithMarket("0007", today);
+
+            assertThat(result.sectorCode()).isEqualTo("0007");
+            verify(sectorInsightPort).findLatestBefore("0007", today);
+            verify(sectorInsightPort).findByCodesAndDate(List.of("0007", "0001"), yesterday);
+        }
+
+        @Test
+        @DisplayName("당일 데이터도 없고 최근 데이터도 없으면 예외를 던진다")
+        void throwsException_whenNoDataExists() {
+            LocalDate today = LocalDate.now();
+            given(sectorInsightPort.findBySectorCodeAndDate("0007", today)).willReturn(Optional.empty());
+            given(sectorInsightPort.findLatestBefore("0007", today)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> sectorInsightService.compareWithMarket("0007", today))
+                    .isInstanceOf(SectorDomainException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Close #176

## 변경 사항

### SectorInsightService.java
- `getSectorDetail`: `findBySectorCodeAndDate` 실패 시 `findLatestBefore` fallback 추가
- `compareWithMarket`: 동일한 fallback 추가 + fallback 후 `sector.getBaseDate()`를 `effectiveDate`로 사용해 후속 시장 조회(`findByCodesAndDate`, `findHistoryByCode`)도 일관된 날짜로 처리

### SectorInsightServiceTest.java (신규)
- 당일 데이터 존재 시 정상 반환
- 당일 데이터 없을 때 `findLatestBefore` 결과 반환
- 데이터 전혀 없을 때 예외 발생
- `compareWithMarket` fallback 시 `effectiveDate` 기준 시장 조회 검증

## 테스트

```
./gradlew :stockwellness-core:test --tests "org.stockwellness.application.service.stock.SectorInsightServiceTest"
```
BUILD SUCCESSFUL — 5개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)