### PR TITLE
fix(#177): PortfolioAccessDeniedException 오류 코드 401 → 403 수정

### DIFF
--- a/stockwellness-core/src/main/java/org/stockwellness/domain/portfolio/exception/PortfolioAccessDeniedException.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/domain/portfolio/exception/PortfolioAccessDeniedException.java
@@ -4,6 +4,6 @@ import org.stockwellness.global.error.ErrorCode;
 
 public class PortfolioAccessDeniedException extends PortfolioDomainException {
     public PortfolioAccessDeniedException() {
-        super(ErrorCode.UNAUTHORIZED);
+        super(ErrorCode.ACCESS_DENIED);
     }
 }


### PR DESCRIPTION
## 관련 이슈

Close #177

## 변경 사항

`PortfolioAccessDeniedException`이 `ErrorCode.UNAUTHORIZED`(A001, 401) 대신
`ErrorCode.ACCESS_DENIED`(A002, 403)를 사용하도록 수정.

## 문제

인증된 사용자가 타인의 포트폴리오에 접근할 때 401이 반환되어 FE Response 인터셉터가
토큰 재발급을 시도 → 재시도 → 401 재수신 → 로그인 리다이렉트 루프 발생.

## 검증

- `ErrorCode.ACCESS_DENIED`(A002, 403)는 기존에 `WatchlistService`에서 사용 중 — 추가 불필요
- `AuthController` 등 기존 `UNAUTHORIZED`(A001) 사용처 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)