### PR TITLE
fix(#178,#181): SliceResponse DTO 추가 및 검색 API hasNext 누락·size 기본값 수정

### DIFF
--- a/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/stock/StockController.java
+++ b/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/stock/StockController.java
@@ -3,6 +3,7 @@ package org.stockwellness.adapter.in.web.stock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
+import org.stockwellness.global.common.response.SliceResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.stockwellness.application.port.in.stock.StockPriceUseCase;
@@ -41,13 +42,13 @@ public class StockController {
      * 통합 종목 검색
      */
     @GetMapping("/search")
-    public ApiResponse<Slice<StockSearchResult>> searchStocks(
+    public ApiResponse<SliceResponse<StockSearchResult>> searchStocks(
             @AuthenticationPrincipal MemberPrincipal member,
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) MarketType marketType,
             @RequestParam(required = false) StockStatus status,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "20") int size
     ) {
         SearchStockQuery query = new SearchStockQuery(keyword, marketType, status, page, size);
         Slice<StockSearchResult> result = stockUseCase.searchStocks(query);
@@ -57,7 +58,7 @@ public class StockController {
             stockSearchUseCase.saveSearchHistory(member.id(), keyword);
         }
 
-        return ApiResponse.success(result);
+        return ApiResponse.success(SliceResponse.from(result));
     }
 
     /**

--- a/stockwellness-api/src/test/java/org/stockwellness/adapter/in/web/stock/StockControllerTest.java
+++ b/stockwellness-api/src/test/java/org/stockwellness/adapter/in/web/stock/StockControllerTest.java
@@ -62,22 +62,19 @@ class StockControllerTest extends RestDocsSupport {
                 fieldWithPath("data.content[].marketType").description("마켓 타입"),
                 fieldWithPath("data.content[].sectorName").description("섹터명"),
                 fieldWithPath("data.content[].status").description("종목 상태"),
-                fieldWithPath("data.pageable").description("페이징 정보"),
-                fieldWithPath("data.last").description("마지막 페이지 여부"),
-                fieldWithPath("data.numberOfElements").description("현재 페이지 엘리먼트 수"),
+                fieldWithPath("data.number").description("현재 페이지 번호 (0-based)"),
+                fieldWithPath("data.size").description("페이지 크기"),
+                fieldWithPath("data.numberOfElements").description("현재 페이지 항목 수"),
                 fieldWithPath("data.first").description("첫 번째 페이지 여부"),
-                fieldWithPath("data.size").description("페이지 사이즈"),
-                fieldWithPath("data.number").description("현재 페이지 번호"),
-                fieldWithPath("data.sort.empty").description("정렬 정보 비어있음 여부"),
-                fieldWithPath("data.sort.sorted").description("정렬 여부"),
-                fieldWithPath("data.sort.unsorted").description("미정렬 여부"),
-                fieldWithPath("data.empty").description("결과 비어있음 여부")
+                fieldWithPath("data.last").description("마지막 페이지 여부"),
+                fieldWithPath("data.hasNext").description("다음 페이지 존재 여부"),
+                fieldWithPath("data.empty").description("결과 없음 여부")
         ));
 
         mockMvc.perform(get("/api/v1/stocks/search")
                         .param("keyword", "삼성")
                         .param("page", "0")
-                        .param("size", "10")
+                        .param("size", "20")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))

--- a/stockwellness-core/src/main/java/org/stockwellness/global/common/response/SliceResponse.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/global/common/response/SliceResponse.java
@@ -1,0 +1,29 @@
+package org.stockwellness.global.common.response;
+
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public record SliceResponse<T>(
+        List<T> content,
+        int number,
+        int size,
+        int numberOfElements,
+        boolean first,
+        boolean last,
+        boolean hasNext,
+        boolean empty
+) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(
+                slice.getContent(),
+                slice.getNumber(),
+                slice.getSize(),
+                slice.getNumberOfElements(),
+                slice.isFirst(),
+                slice.isLast(),
+                slice.hasNext(),
+                slice.isEmpty()
+        );
+    }
+}


### PR DESCRIPTION
## 관련 이슈

Close #178
Close #181

## 변경 사항

### SliceResponse.java (신규)
`stockwellness-core/.../global/common/response/SliceResponse<T>` 레코드 추가.
`hasNext`, `first`, `last`, `size`, `number`, `numberOfElements`, `empty`, `content` 필드 포함.
`SliceResponse.from(Slice<T>)` 팩토리 메서드로 변환.

### StockController.java
- `searchStocks` 반환 타입 `Slice<StockSearchResult>` → `SliceResponse<StockSearchResult>`
- `ApiResponse.success(SliceResponse.from(result))`로 변환
- 기본 `size` 파라미터 `10` → `20` (API 명세 일치)

### StockControllerTest.java
- `responseFields`에서 `pageable`, `sort.*` 제거 → `hasNext` 추가
- 요청 `size` 파라미터 `10` → `20`

## 테스트

```
./gradlew :stockwellness-api:test --tests "org.stockwellness.adapter.in.web.stock.StockControllerTest.searchStocks"
```
BUILD SUCCESSFUL