### PR TITLE
fix(#179): BacktestResponse benchmarkReturnRate 스칼라 필드 추가 및 REST Docs 문서화

### DIFF
--- a/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/portfolio/PortfolioAnalysisController.java
+++ b/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/portfolio/PortfolioAnalysisController.java
@@ -97,7 +97,7 @@ public class PortfolioAnalysisController {
         );
 
         BacktestResult result = portfolioFacade.runBacktest(command);
-        return ApiResponse.success(BacktestResponse.from(result));
+        return ApiResponse.success(BacktestResponse.from(result, request.benchmarkTicker()));
     }
 
     /**

--- a/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/portfolio/dto/BacktestResponse.java
+++ b/stockwellness-api/src/main/java/org/stockwellness/adapter/in/web/portfolio/dto/BacktestResponse.java
@@ -26,6 +26,7 @@ public record BacktestResponse(
         BigDecimal totalValue,
         BigDecimal totalInvested,
         BigDecimal returnRate,
+        BigDecimal benchmarkReturnRate, // 주요 벤치마크 수익률 (FE 호환용 스칼라)
         Map<String, BigDecimal> benchmarkReturnRates // 다중 지수 수익률
     ) {}
 
@@ -37,10 +38,14 @@ public record BacktestResponse(
         BigDecimal beta
     ) {}
 
-    public static BacktestResponse from(BacktestResult result) {
+    public static BacktestResponse from(BacktestResult result, String primaryBenchmarkTicker) {
         return new BacktestResponse(
             result.dailyResults().stream()
-                .map(r -> new DailyResult(r.date(), r.totalValue(), r.totalInvested(), r.returnRate(), r.benchmarkReturnRates()))
+                .map(r -> new DailyResult(
+                    r.date(), r.totalValue(), r.totalInvested(), r.returnRate(),
+                    r.benchmarkReturnRates().getOrDefault(primaryBenchmarkTicker, BigDecimal.ZERO),
+                    r.benchmarkReturnRates()
+                ))
                 .toList(),
             result.cagr(),
             result.mdd(),

--- a/stockwellness-api/src/test/java/org/stockwellness/adapter/in/web/portfolio/PortfolioAnalysisControllerTest.java
+++ b/stockwellness-api/src/test/java/org/stockwellness/adapter/in/web/portfolio/PortfolioAnalysisControllerTest.java
@@ -194,7 +194,7 @@ class PortfolioAnalysisControllerTest extends RestDocsSupport {
         BacktestRequest request = new BacktestRequest(
                 "LUMP_SUM",
                 BigDecimal.valueOf(1000000),
-                "^KS11",
+                "KOSPI",
                 "MONTHLY",
                 Map.of("005930", BigDecimal.valueOf(100))
         );
@@ -205,6 +205,7 @@ class PortfolioAnalysisControllerTest extends RestDocsSupport {
                 fieldWithPath("data.dailyResults[].totalValue").description("해당 일자 총 자산 가치"),
                 fieldWithPath("data.dailyResults[].totalInvested").description("해당 일자 총 누적 투자금"),
                 fieldWithPath("data.dailyResults[].returnRate").description("해당 일자 누적 수익률 (%)"),
+                fieldWithPath("data.dailyResults[].benchmarkReturnRate").description("주요 벤치마크 누적 수익률 (%) — 요청한 benchmarkTicker 기준 스칼라"),
                 subsectionWithPath("data.dailyResults[].benchmarkReturnRates").description("벤치마크 지수별 해당 일자 수익률 (Map<Ticker, Rate>)"),
                 fieldWithPath("data.cagr").description("연평균 복리 수익률 (CAGR)"),
                 fieldWithPath("data.mdd").description("최대 낙폭 (MDD)"),


### PR DESCRIPTION
## 관련 이슈

Close #179

## 변경 사항

### BacktestResponse.java
- `DailyResult`에 `benchmarkReturnRate` (BigDecimal) 스칼라 필드 추가
- `from()` 서명 변경: `from(result, primaryBenchmarkTicker)` — ticker로 Map에서 값을 꺼내 스칼라 필드 세팅. ticker 없을 경우 `BigDecimal.ZERO` 반환

### PortfolioAnalysisController.java
- `BacktestResponse.from(result, request.benchmarkTicker())` 호출

### PortfolioAnalysisControllerTest.java
- `BacktestRequest` 픽스처 `benchmarkTicker`: `"^KS11"` → `"KOSPI"` (mock map key 일치시켜 `benchmarkReturnRate` 값이 정상 세팅)
- `responseFields`에 `dailyResults[].benchmarkReturnRate` 추가

## 테스트

```
./gradlew :stockwellness-api:test --tests "...PortfolioAnalysisControllerTest.run_backtest"
```
BUILD SUCCESSFUL