### PR TITLE
fix(#182): ChartPeriod / ChartFrequency 잘못된 파라미터 400 예외 처리

### DIFF
--- a/stockwellness-core/src/main/java/org/stockwellness/domain/stock/exception/InvalidPeriodException.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/domain/stock/exception/InvalidPeriodException.java
@@ -1,0 +1,9 @@
+package org.stockwellness.domain.stock.exception;
+
+import org.stockwellness.global.error.ErrorCode;
+
+public class InvalidPeriodException extends StockDomainException {
+    public InvalidPeriodException(String label) {
+        super(ErrorCode.INVALID_INPUT_VALUE);
+    }
+}

--- a/stockwellness-core/src/main/java/org/stockwellness/domain/stock/price/ChartFrequency.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/domain/stock/price/ChartFrequency.java
@@ -1,5 +1,7 @@
 package org.stockwellness.domain.stock.price;
 
+import org.stockwellness.domain.stock.exception.InvalidPeriodException;
+
 /**
  * 차트 데이터 집계 주기 (일, 주, 월)
  */
@@ -12,7 +14,7 @@ public enum ChartFrequency {
         try {
             return valueOf(frequency.toUpperCase());
         } catch (IllegalArgumentException | NullPointerException e) {
-            return DAILY;
+            throw new InvalidPeriodException(frequency);
         }
     }
 }

--- a/stockwellness-core/src/main/java/org/stockwellness/domain/stock/price/ChartPeriod.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/domain/stock/price/ChartPeriod.java
@@ -3,6 +3,8 @@ package org.stockwellness.domain.stock.price;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import org.stockwellness.domain.stock.exception.InvalidPeriodException;
+
 import java.time.LocalDate;
 import java.util.function.Function;
 
@@ -33,6 +35,6 @@ public enum ChartPeriod {
                 return period;
             }
         }
-        return ONE_YEAR; // 기본값
+        throw new InvalidPeriodException(label);
     }
 }


### PR DESCRIPTION
## 관련 이슈

Close #182

## 변경 사항

### InvalidPeriodException.java (신규)
`StockDomainException` 하위 예외. `ErrorCode.INVALID_INPUT_VALUE`(G001, 400) 사용.

### ChartPeriod.fromLabel
매칭 실패 시 `ONE_YEAR` 반환 → `InvalidPeriodException` throw.

### ChartFrequency.fromString
매칭 실패 시 `DAILY` 반환 → `InvalidPeriodException` throw.

## Before / After

```
# Before
GET /api/v1/stocks/{ticker}/returns?period=INVALID
→ 200 OK, period: "1Y"

# After
GET /api/v1/stocks/{ticker}/returns?period=INVALID
→ 400 { "code": "G001", "message": "..." }
```

## 테스트

- `StockControllerTest` (기존 테스트, 유효한 period 파라미터 사용) BUILD SUCCESSFUL — 회귀 없음