### PR TITLE
fix(#183): PortfolioUpdateRequest.items 최소 1개 @NotEmpty 검증 추가

### DIFF
--- a/stockwellness-core/src/main/java/org/stockwellness/application/port/in/portfolio/dto/PortfolioUpdateRequest.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/application/port/in/portfolio/dto/PortfolioUpdateRequest.java
@@ -1,9 +1,11 @@
 package org.stockwellness.application.port.in.portfolio.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+
 import java.util.List;
 
 public record PortfolioUpdateRequest(
     String name,
     String description,
-    List<PortfolioItemRequest> items
+    @NotEmpty(message = "포트폴리오에 최소 1개 이상의 종목이 필요합니다.") List<PortfolioItemRequest> items
 ) {}


### PR DESCRIPTION
## 관련 이슈

Close #183

## ⚠️ 정책 결정 필요 — 병합 전 확인

> **빈 포트폴리오를 허용할 경우 이 PR을 병합하지 마세요.**
> 최소 1개 종목 유지 정책이 확정된 경우에만 병합합니다.

## 변경 사항

### PortfolioUpdateRequest.java
`items` 필드에 `@NotEmpty` 추가.

```java
@NotEmpty(message = "포트폴리오에 최소 1개 이상의 종목이 필요합니다.")
List<PortfolioItemRequest> items
```

`PortfolioController.updatePortfolio`에 이미 `@Valid`가 선언되어 있어 별도 수정 불필요.

## Before / After

```
# Before
PUT /api/v1/portfolios/{id}  body: { "items": [] }
→ 200 OK (전종목 삭제)

# After
PUT /api/v1/portfolios/{id}  body: { "items": [] }
→ 400 { "code": "G001", "message": "포트폴리오에 최소 1개 이상의 종목이 필요합니다." }
```