### PR TITLE
[refactor] 종목 수급 랭킹 API Tail Latency 개선

### DIFF
--- a/stockwellness-api/src/main/java/org/stockwellness/adapter/in/kafka/StockPriceUpdateConsumer.java
+++ b/stockwellness-api/src/main/java/org/stockwellness/adapter/in/kafka/StockPriceUpdateConsumer.java
@@ -47,7 +47,8 @@ public class StockPriceUpdateConsumer {
                 CacheType.SECTOR_RANKING,
                 CacheType.SECTOR_SUPPLY,
                 CacheType.MARKET_DASHBOARD,
-                CacheType.MARKET_BREADTH
+                CacheType.MARKET_BREADTH,
+                CacheType.STOCK_SUPPLY_RANKING
         );
 
         // 2. 영향을 받는 포트폴리오 식별 및 분석 캐시 무효화

--- a/stockwellness-api/src/test/java/org/stockwellness/adapter/in/kafka/StockPriceUpdateConsumerTest.java
+++ b/stockwellness-api/src/test/java/org/stockwellness/adapter/in/kafka/StockPriceUpdateConsumerTest.java
@@ -28,6 +28,7 @@ import static org.stockwellness.domain.common.cache.CacheType.MARKET_BREADTH;
 import static org.stockwellness.domain.common.cache.CacheType.MARKET_DASHBOARD;
 import static org.stockwellness.domain.common.cache.CacheType.SECTOR_RANKING;
 import static org.stockwellness.domain.common.cache.CacheType.SECTOR_SUPPLY;
+import static org.stockwellness.domain.common.cache.CacheType.STOCK_SUPPLY_RANKING;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -77,6 +78,7 @@ class StockPriceUpdateConsumerTest {
                 verify(cacheManager).getCache(SECTOR_SUPPLY.getCacheName());
                 verify(cacheManager).getCache(MARKET_DASHBOARD.getCacheName());
                 verify(cacheManager).getCache(MARKET_BREADTH.getCacheName());
+                verify(cacheManager).getCache(STOCK_SUPPLY_RANKING.getCacheName());
                 verify(cacheManager).getCache(AI_ANALYSIS.getCacheName());
                 verify(mockCache, atLeastOnce()).clear();
                 verify(mockCache, atLeastOnce()).evict(anyLong());

--- a/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/stock/repository/StockPriceRepositoryImpl.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/stock/repository/StockPriceRepositoryImpl.java
@@ -58,13 +58,14 @@ public class StockPriceRepositoryImpl implements StockPriceRepositoryCustom {
     public Optional<LocalDate> findLatestInvestorTradeDate() {
         return Optional.ofNullable(
                 queryFactory
-                        .select(stockInvestorTrade.id.baseDate.max())
+                        .select(stockInvestorTrade.id.baseDate)
                         .from(stockInvestorTrade)
                         .join(stockPrice).on(
                                 stockPrice.stock.eq(stockInvestorTrade.stock)
                                         .and(stockPrice.id.baseDate.eq(stockInvestorTrade.id.baseDate))
                         )
-                        .fetchOne()
+                        .orderBy(stockInvestorTrade.id.baseDate.desc())
+                        .fetchFirst()
         );
     }
 
@@ -119,7 +120,7 @@ public class StockPriceRepositoryImpl implements StockPriceRepositoryCustom {
     ) {
         NumberExpression<Long> netBuyingQuantity = buyingQty.coalesce(0L);
         NumberExpression<BigDecimal> netBuyingAmount = buyingAmt.coalesce(BigDecimal.ZERO);
-        BooleanExpression directionFilter = getDirectionFilter(netBuyingAmount, direction);
+        BooleanExpression directionFilter = getDirectionFilter(buyingAmt, direction);
         NumberExpression<BigDecimal> currentPrice = stockPrice.closePrice.coalesce(BigDecimal.ZERO);
         NumberExpression<BigDecimal> transactionAmount = stockPrice.transactionAmt.coalesce(BigDecimal.ZERO);
         NumberExpression<BigDecimal> fluctuationRate = new CaseBuilder()
@@ -150,7 +151,7 @@ public class StockPriceRepositoryImpl implements StockPriceRepositoryCustom {
                         stockInvestorTrade.id.baseDate.eq(date),
                         directionFilter
                 )
-                .orderBy(direction == TradeDirection.BUY ? netBuyingAmount.desc() : netBuyingAmount.asc())
+                .orderBy(direction == TradeDirection.BUY ? buyingAmt.desc() : buyingAmt.asc())
                 .limit(limit)
                 .fetch();
     }

--- a/stockwellness-core/src/main/resources/db/migration/V21__add_stock_supply_ranking_indexes.sql
+++ b/stockwellness-core/src/main/resources/db/migration/V21__add_stock_supply_ranking_indexes.sql
@@ -1,0 +1,8 @@
+CREATE INDEX IF NOT EXISTS idx_investor_trade_base_date_stock
+    ON stock_investor_trade (base_date DESC, stock_id);
+
+CREATE INDEX IF NOT EXISTS idx_investor_trade_orgn_ranking
+    ON stock_investor_trade (base_date, orgn_ntby_tr_pbmn, stock_id);
+
+CREATE INDEX IF NOT EXISTS idx_investor_trade_frgn_ranking
+    ON stock_investor_trade (base_date, frgn_ntby_tr_pbmn, stock_id);


### PR DESCRIPTION
## 개요
- `stock-supply-ranking` API의 Tail Latency 개선을 위해 수급 랭킹 조회 경로를 최적화했습니다.
- 수급 기준일 조회와 기관/외국인 수급 랭킹 정렬이 인덱스를 활용하도록 쿼리와 인덱스를 조정했습니다.
- 시세 업데이트 이벤트 발생 시 수급 랭킹 캐시도 함께 무효화되도록 보강했습니다.

## 원인
- 수급 랭킹 쿼리가 `base_date`로 필터링한 뒤 기관/외국인 순매수 금액으로 정렬하지만, 금액 정렬에 맞는 인덱스가 없었습니다.
- 최신 수급 기준일 조회가 `max(base_date)` 집계 방식이라 조인 가능한 전체 수급 데이터를 넓게 스캔했습니다.
- `stockSupplyRanking:v1` 캐시가 시세 업데이트 이벤트에서 무효화되지 않아 배치 이후 응답 일관성과 캐시 미스 타이밍이 불명확했습니다.

## 변경 사항
- 최신 수급 기준일 조회를 `base_date DESC LIMIT 1` 방식으로 변경했습니다.
- 수급 랭킹 필터/정렬 기준에서 인덱스 사용을 방해하는 `coalesce` 적용을 제거했습니다.
- `stock_investor_trade`에 최신 기준일 조회 및 기관/외국인 수급 랭킹용 인덱스를 추가했습니다.
- `StockPriceUpdatedEvent` 처리 시 `stockSupplyRanking:v1` 캐시를 함께 무효화하도록 수정했습니다.

## 검증
- `./gradlew :stockwellness-core:test --tests "org.stockwellness.adapter.out.persistence.stock.repository.StockPriceRepositoryTest"`
- `./gradlew :stockwellness-api:test --tests "org.stockwellness.adapter.in.kafka.StockPriceUpdateConsumerTest"`
- `git diff --check`

## 실행 계획 확인
- 최신 수급 기준일 조회: 약 `96ms` -> 약 `0.42ms`
- 기관 BUY 랭킹: 약 `45ms` -> 약 `0.48ms`
- 외국인 BUY 랭킹: 약 `7ms` -> 약 `0.52ms`
- SELL 랭킹 경로: 약 `0.48ms ~ 0.63ms` 수준 확인

Closes #227
