### PR TITLE
test(core): 포트폴리오 진단 정책 단위 테스트 추가 (#238)

### DIFF
--- a/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/stock/StockDataAdapter.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/stock/StockDataAdapter.java
@@ -9,6 +9,7 @@ import org.stockwellness.domain.stock.price.StockPrice;
 import org.stockwellness.domain.stock.analysis.AiAnalysisContext;
 import org.stockwellness.domain.stock.analysis.TechnicalCalculator;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -43,9 +44,21 @@ public class StockDataAdapter implements StockDataPort {
     }
 
     private StockWellnessDetail convertToDetail(StockPrice stockPrice, AiAnalysisContext context) {
-        String rsiStatus = TechnicalCalculator.analyzeRsiLevel(stockPrice.getIndicators().getRsi14());
-        String aiInsight = null;
+        BigDecimal rsi = stockPrice.getIndicators() != null ? stockPrice.getIndicators().getRsi14() : null;
+        String rsiStatus = TechnicalCalculator.analyzeRsiLevel(rsi);
 
-        return null;
+        // context가 null일 경우를 대비한 방어 로직 및 추세 정보 기반 insight 추출
+        String aiInsight = (context != null && context.technicalSignal() != null)
+                ? context.technicalSignal().trendStatus().getDescription()
+                : "데이터가 부족하여 AI 분석을 제공할 수 없습니다.";
+
+        return new StockWellnessDetail(
+                stockPrice.getStock().getStandardCode(),
+                stockPrice.getClosePrice(),
+                stockPrice.getFluctuationRate(),
+                rsi,
+                rsiStatus,
+                aiInsight
+        );
     }
 }

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/batch/BenchmarkPriceSyncServiceTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/batch/BenchmarkPriceSyncServiceTest.java
@@ -1,0 +1,115 @@
+package org.stockwellness.application.service.batch;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.stockwellness.application.port.in.batch.BenchmarkPriceSyncUseCase;
+import org.stockwellness.application.port.out.stock.BenchmarkPricePort;
+import org.stockwellness.domain.stock.BenchmarkType;
+import org.stockwellness.domain.stock.price.BenchmarkPrice;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BenchmarkPriceSyncService 단위 테스트")
+class BenchmarkPriceSyncServiceTest {
+
+    @Mock
+    private BenchmarkPricePort benchmarkPricePort;
+
+    @Test
+    @DisplayName("등락률이 없으면 이전 종가를 조회해 등락률을 계산한다")
+    void toBenchmarkPrice_CalculatesChangeRateFromPreviousClose() {
+        BenchmarkPriceSyncService service = new BenchmarkPriceSyncService(benchmarkPricePort);
+        LocalDate baseDate = LocalDate.of(2026, 4, 24);
+        BenchmarkPrice previous = BenchmarkPrice.of("코스피 200", "2001", baseDate.minusDays(1), BigDecimal.valueOf(100));
+        given(benchmarkPricePort.findLatestBefore("2001", baseDate)).willReturn(Optional.of(previous));
+
+        BenchmarkPriceSyncUseCase.BenchmarkPriceResult result = service.toBenchmarkPrice(new BenchmarkPriceSyncUseCase.BenchmarkPriceCommand(
+                BenchmarkType.KOSPI_200,
+                baseDate,
+                BigDecimal.valueOf(101),
+                BigDecimal.valueOf(106),
+                BigDecimal.valueOf(99),
+                BigDecimal.valueOf(105),
+                null,
+                1_000L
+        ));
+
+        assertThat(result.benchmarkPrice().getTicker()).isEqualTo("2001");
+        assertThat(result.benchmarkPrice().getClosePrice()).isEqualByComparingTo("105");
+        assertThat(result.benchmarkPrice().getChangeRate()).isEqualByComparingTo("5.000000");
+    }
+
+    @Test
+    @DisplayName("이전 종가 캐시가 있으면 포트를 다시 조회하지 않는다")
+    void toBenchmarkPrice_UsesCachedPreviousClose() {
+        BenchmarkPriceSyncService service = new BenchmarkPriceSyncService(benchmarkPricePort);
+        LocalDate firstDate = LocalDate.of(2026, 4, 23);
+        LocalDate secondDate = LocalDate.of(2026, 4, 24);
+        BenchmarkPrice previous = BenchmarkPrice.of("코스피 200", "2001", firstDate.minusDays(1), BigDecimal.valueOf(100));
+        given(benchmarkPricePort.findLatestBefore("2001", firstDate)).willReturn(Optional.of(previous));
+
+        service.toBenchmarkPrice(command(BenchmarkType.KOSPI_200, firstDate, BigDecimal.valueOf(105), null));
+        BenchmarkPriceSyncUseCase.BenchmarkPriceResult second = service.toBenchmarkPrice(
+                command(BenchmarkType.KOSPI_200, secondDate, BigDecimal.valueOf(110), null)
+        );
+
+        assertThat(second.benchmarkPrice().getChangeRate()).isEqualByComparingTo("4.761900");
+        verify(benchmarkPricePort, times(1)).findLatestBefore("2001", firstDate);
+    }
+
+    @Test
+    @DisplayName("이전 종가가 없으면 등락률을 0으로 저장한다")
+    void toBenchmarkPrice_DefaultsChangeRateToZeroWhenPreviousCloseMissing() {
+        BenchmarkPriceSyncService service = new BenchmarkPriceSyncService(benchmarkPricePort);
+        LocalDate baseDate = LocalDate.of(2026, 4, 24);
+        given(benchmarkPricePort.findLatestBefore("2001", baseDate)).willReturn(Optional.empty());
+
+        BenchmarkPriceSyncUseCase.BenchmarkPriceResult result = service.toBenchmarkPrice(
+                command(BenchmarkType.KOSPI_200, baseDate, BigDecimal.valueOf(105), null)
+        );
+
+        assertThat(result.benchmarkPrice().getChangeRate()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("국내 지수의 유효한 등락률은 재계산하지 않고 그대로 사용한다")
+    void toBenchmarkPrice_KeepsProvidedDomesticChangeRate() {
+        BenchmarkPriceSyncService service = new BenchmarkPriceSyncService(benchmarkPricePort);
+        LocalDate baseDate = LocalDate.of(2026, 4, 24);
+
+        BenchmarkPriceSyncUseCase.BenchmarkPriceResult result = service.toBenchmarkPrice(
+                command(BenchmarkType.KOSPI_200, baseDate, BigDecimal.valueOf(105), BigDecimal.valueOf(1.25))
+        );
+
+        assertThat(result.benchmarkPrice().getChangeRate()).isEqualByComparingTo("1.25");
+    }
+
+    private BenchmarkPriceSyncUseCase.BenchmarkPriceCommand command(
+            BenchmarkType type,
+            LocalDate baseDate,
+            BigDecimal closePrice,
+            BigDecimal changeRate
+    ) {
+        return new BenchmarkPriceSyncUseCase.BenchmarkPriceCommand(
+                type,
+                baseDate,
+                closePrice.subtract(BigDecimal.ONE),
+                closePrice.add(BigDecimal.ONE),
+                closePrice.subtract(BigDecimal.TEN),
+                closePrice,
+                changeRate,
+                1_000L
+        );
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/batch/SectorEodBatchServiceTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/batch/SectorEodBatchServiceTest.java
@@ -1,0 +1,171 @@
+package org.stockwellness.application.service.batch;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.stockwellness.adapter.out.external.kis.dto.SectorApiDto;
+import org.stockwellness.application.port.in.batch.SectorEodSyncUseCase;
+import org.stockwellness.application.port.out.sector.LoadSectorAiPort;
+import org.stockwellness.application.port.out.stock.MarketIndexPort;
+import org.stockwellness.application.port.out.stock.SectorInsightPort;
+import org.stockwellness.application.port.out.stock.StockPort;
+import org.stockwellness.application.port.out.stock.StockPricePort;
+import org.stockwellness.application.service.stock.SectorAnalysisService;
+import org.stockwellness.domain.stock.*;
+import org.stockwellness.domain.stock.insight.MarketIndex;
+import org.stockwellness.domain.stock.insight.SectorIndicators;
+import org.stockwellness.domain.stock.insight.SectorInsight;
+import org.stockwellness.domain.stock.price.StockPrice;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SectorEodBatchService 단위 테스트")
+class SectorEodBatchServiceTest {
+
+    @Mock
+    private MarketIndexPort marketIndexPort;
+
+    @Mock
+    private SectorInsightPort sectorInsightPort;
+
+    @Mock
+    private StockPort stockPort;
+
+    @Mock
+    private StockPricePort stockPricePort;
+
+    @Mock
+    private SectorAnalysisService sectorAnalysisService;
+
+    @Mock
+    private LoadSectorAiPort loadSectorAiPort;
+
+    @Test
+    @DisplayName("섹터 코드는 trim과 중복 제거 후 선로딩한다")
+    void prepareSync_NormalizesSectorCodes() {
+        SectorEodBatchService service = service();
+        LocalDate targetDate = LocalDate.of(2026, 4, 24);
+        given(stockPricePort.findAllByDate(targetDate)).willReturn(List.of());
+        given(stockPort.findBySectorCode(null)).willReturn(List.of());
+        given(marketIndexPort.findAll()).willReturn(List.of());
+        given(sectorInsightPort.findLatestBeforeByCodes(anyList(), eq(targetDate))).willReturn(Map.of());
+        given(sectorInsightPort.findPastPricesByCodes(anyList(), eq(targetDate), eq(119))).willReturn(Map.of());
+
+        service.prepareSync(targetDate, Arrays.asList(" 0029 ", "0029", "", "  ", "0027", null));
+
+        ArgumentCaptor<List<String>> codeCaptor = ArgumentCaptor.forClass(List.class);
+        verify(sectorInsightPort).findLatestBeforeByCodes(codeCaptor.capture(), eq(targetDate));
+        assertThat(codeCaptor.getValue()).containsExactlyInAnyOrder("0029", "0027");
+        verify(sectorInsightPort).findPastPricesByCodes(codeCaptor.capture(), eq(targetDate), eq(119));
+        assertThat(codeCaptor.getValue()).containsExactlyInAnyOrder("0029", "0027");
+    }
+
+    @Test
+    @DisplayName("syncSector는 캐시 데이터로 분석 서비스를 호출한다")
+    void syncSector_DelegatesWithCachedSectorData() {
+        SectorEodBatchService service = service();
+        LocalDate targetDate = LocalDate.of(2026, 4, 24);
+        MarketIndex marketIndex = MarketIndex.of("0029", "전기전자");
+        Stock stock = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW,
+                StockSector.of("0001", "0029", null, "전기전자"), StockStatus.ACTIVE);
+        StockPrice price = StockPrice.of(stock, targetDate, BigDecimal.valueOf(100), BigDecimal.valueOf(110),
+                BigDecimal.valueOf(90), BigDecimal.valueOf(105), BigDecimal.valueOf(101), BigDecimal.valueOf(2),
+                1_000L, BigDecimal.valueOf(2), null);
+        SectorInsight previousInsight = sectorInsight(targetDate.minusDays(1));
+        SectorInsight analyzed = sectorInsight(targetDate);
+        List<BigDecimal> pastPrices = List.of(BigDecimal.valueOf(900), BigDecimal.valueOf(920));
+
+        given(stockPricePort.findAllByDate(targetDate)).willReturn(List.of(price));
+        given(stockPort.findBySectorCode(null)).willReturn(List.of(stock));
+        given(marketIndexPort.findAll()).willReturn(List.of(marketIndex));
+        given(sectorInsightPort.findLatestBeforeByCodes(List.of("0029"), targetDate)).willReturn(Map.of("0029", previousInsight));
+        given(sectorInsightPort.findPastPricesByCodes(List.of("0029"), targetDate, 119)).willReturn(Map.of("0029", pastPrices));
+        given(sectorAnalysisService.analyze(eq(marketIndex), any(), eq(previousInsight), eq(pastPrices), eq(List.of(price))))
+                .willReturn(analyzed);
+
+        SectorEodSyncUseCase.SectorEodResult result = service.syncSector(
+                new SectorEodSyncUseCase.SectorSyncCommand(sectorApiDto(targetDate))
+        );
+
+        assertThat(result.sectorInsight()).isSameAs(analyzed);
+        verify(sectorAnalysisService).analyze(eq(marketIndex), any(SectorApiDto.class), eq(previousInsight), eq(pastPrices), eq(List.of(price)));
+    }
+
+    @Test
+    @DisplayName("AI 비활성화 상태에서는 기존 섹터 인사이트를 그대로 반환한다")
+    void enrichAiOpinion_ReturnsInsightWithoutAiWhenDisabled() {
+        SectorEodBatchService service = service();
+        ReflectionTestUtils.setField(service, "aiEnabled", false);
+        SectorInsight insight = sectorInsight(LocalDate.of(2026, 4, 24));
+
+        SectorEodSyncUseCase.SectorEodResult result = service.enrichAiOpinion(
+                new SectorEodSyncUseCase.SectorAiAnalysisCommand(insight)
+        );
+
+        assertThat(result.sectorInsight()).isSameAs(insight);
+        verify(loadSectorAiPort, never()).generateSectorOpinion(any());
+    }
+
+    @Test
+    @DisplayName("섹터 인사이트가 없으면 AI 보강도 null 결과를 반환한다")
+    void enrichAiOpinion_ReturnsNullWhenInsightMissing() {
+        SectorEodBatchService service = service();
+
+        SectorEodSyncUseCase.SectorEodResult result = service.enrichAiOpinion(
+                new SectorEodSyncUseCase.SectorAiAnalysisCommand(null)
+        );
+
+        assertThat(result.sectorInsight()).isNull();
+        verify(loadSectorAiPort, never()).generateSectorOpinion(any());
+    }
+
+    private SectorEodBatchService service() {
+        return new SectorEodBatchService(
+                marketIndexPort,
+                sectorInsightPort,
+                stockPort,
+                stockPricePort,
+                sectorAnalysisService,
+                loadSectorAiPort
+        );
+    }
+
+    private SectorApiDto sectorApiDto(LocalDate targetDate) {
+        return new SectorApiDto(
+                "0029",
+                "전기전자",
+                targetDate,
+                BigDecimal.valueOf(1000),
+                BigDecimal.valueOf(1.2),
+                10L,
+                20L
+        );
+    }
+
+    private SectorInsight sectorInsight(LocalDate baseDate) {
+        return SectorInsight.of(
+                "전기전자",
+                "0029",
+                MarketType.KOSPI,
+                baseDate,
+                SectorIndicators.of(BigDecimal.valueOf(1000), BigDecimal.valueOf(1.2), 10L, 20L, 2, 1),
+                null,
+                false
+        );
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/batch/StockMasterSyncServiceTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/batch/StockMasterSyncServiceTest.java
@@ -1,0 +1,196 @@
+package org.stockwellness.application.service.batch;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.stockwellness.adapter.out.external.kis.client.KisMasterClient;
+import org.stockwellness.adapter.out.persistence.stock.repository.MarketIndexRepository;
+import org.stockwellness.adapter.out.persistence.stock.repository.StockRepository;
+import org.stockwellness.application.port.in.batch.StockMasterSyncUseCase;
+import org.stockwellness.domain.stock.*;
+import org.stockwellness.domain.stock.insight.MarketIndex;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StockMasterSyncService 단위 테스트")
+class StockMasterSyncServiceTest {
+
+    @Mock
+    private KisMasterClient kisMasterClient;
+
+    @Mock
+    private StockRepository stockRepository;
+
+    @Mock
+    private MarketIndexRepository marketIndexRepository;
+
+    @Test
+    @DisplayName("신규 KOSPI 종목이면 Stock을 생성한다")
+    void upsertKospi_CreatesNewStock() {
+        StockMasterSyncService service = new StockMasterSyncService(kisMasterClient, stockRepository, marketIndexRepository);
+        KospiItem item = kospiItem("005930", "삼성전자");
+        given(marketIndexRepository.findActiveIndexMap()).willReturn(Map.of("0029", MarketIndex.of("0029", "전기전자")));
+        given(stockRepository.findByTicker("005930")).willReturn(Optional.empty());
+
+        StockMasterSyncUseCase.StockMasterSyncResult result = service.upsertKospi(
+                new StockMasterSyncUseCase.KospiMasterSyncCommand(item)
+        );
+
+        assertThat(result.created()).isTrue();
+        assertThat(result.stock().getTicker()).isEqualTo("005930");
+        assertThat(result.stock().getName()).isEqualTo("삼성전자");
+        assertThat(result.stock().getMarketType()).isEqualTo(MarketType.KOSPI);
+        assertThat(result.stock().getSector().getSectorCode()).isEqualTo("0029");
+        assertThat(result.stock().getSector().getSectorName()).isEqualTo("전기전자");
+    }
+
+    @Test
+    @DisplayName("신규 KOSDAQ 종목이면 Stock을 생성한다")
+    void upsertKosdaq_CreatesNewStock() {
+        StockMasterSyncService service = new StockMasterSyncService(kisMasterClient, stockRepository, marketIndexRepository);
+        KosdaqItem item = kosdaqItem("000250", "삼천당제약");
+        given(marketIndexRepository.findActiveIndexMap()).willReturn(Map.of("0027", MarketIndex.of("0027", "제약")));
+        given(stockRepository.findByTicker("000250")).willReturn(Optional.empty());
+
+        StockMasterSyncUseCase.StockMasterSyncResult result = service.upsertKosdaq(
+                new StockMasterSyncUseCase.KosdaqMasterSyncCommand(item)
+        );
+
+        assertThat(result.created()).isTrue();
+        assertThat(result.stock().getTicker()).isEqualTo("000250");
+        assertThat(result.stock().getName()).isEqualTo("삼천당제약");
+        assertThat(result.stock().getMarketType()).isEqualTo(MarketType.KOSDAQ);
+        assertThat(result.stock().getSector().getSectorCode()).isEqualTo("0027");
+        assertThat(result.stock().getSector().getSectorName()).isEqualTo("제약");
+    }
+
+    @Test
+    @DisplayName("기존 종목이면 마스터 정보로 갱신한다")
+    void upsertKospi_UpdatesExistingStock() {
+        StockMasterSyncService service = new StockMasterSyncService(kisMasterClient, stockRepository, marketIndexRepository);
+        Stock existing = Stock.of("005930", "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW,
+                StockSector.of("0001", "0029", null, "전기전자"), StockStatus.ACTIVE);
+        KospiItem item = kospiItem("005930", "삼성전자우");
+        given(marketIndexRepository.findActiveIndexMap()).willReturn(Map.of("0029", MarketIndex.of("0029", "전기전자")));
+        given(stockRepository.findByTicker("005930")).willReturn(Optional.of(existing));
+
+        StockMasterSyncUseCase.StockMasterSyncResult result = service.upsertKospi(
+                new StockMasterSyncUseCase.KospiMasterSyncCommand(item)
+        );
+
+        assertThat(result.created()).isFalse();
+        assertThat(result.stock()).isSameAs(existing);
+        assertThat(existing.getName()).isEqualTo("삼성전자우");
+        assertThat(existing.getSector().getSectorName()).isEqualTo("전기전자");
+    }
+
+    @Test
+    @DisplayName("단축코드가 비어 있으면 종목 동기화를 건너뛴다")
+    void upsertKospi_SkipsBlankShortCode() {
+        StockMasterSyncService service = new StockMasterSyncService(kisMasterClient, stockRepository, marketIndexRepository);
+        KospiItem item = mock(KospiItem.class);
+        given(item.shortCode()).willReturn(" ");
+        given(item.isinCode()).willReturn("KR7000000000");
+
+        StockMasterSyncUseCase.StockMasterSyncResult result = service.upsertKospi(
+                new StockMasterSyncUseCase.KospiMasterSyncCommand(item)
+        );
+
+        assertThat(result.created()).isFalse();
+        assertThat(result.stock()).isNull();
+        verifyNoInteractions(marketIndexRepository, stockRepository);
+    }
+
+    @Test
+    @DisplayName("활성 ticker가 비어 있으면 상장폐지 처리를 건너뛴다")
+    void markDelisted_SkipsEmptyActiveTickers() {
+        StockMasterSyncService service = new StockMasterSyncService(kisMasterClient, stockRepository, marketIndexRepository);
+
+        StockMasterSyncUseCase.StockDelistResult result = service.markDelisted(
+                new StockMasterSyncUseCase.StockDelistCommand(MarketType.KOSPI, Set.of())
+        );
+
+        assertThat(result.marketType()).isEqualTo(MarketType.KOSPI);
+        assertThat(result.delistedCount()).isZero();
+        verify(stockRepository, never()).delistMissingStocks(any(), any());
+    }
+
+    @Test
+    @DisplayName("활성 ticker가 있으면 누락 종목을 상장폐지 처리한다")
+    void markDelisted_DelegatesRepository() {
+        StockMasterSyncService service = new StockMasterSyncService(kisMasterClient, stockRepository, marketIndexRepository);
+        Set<String> activeTickers = Set.of("005930", "000660");
+        given(stockRepository.delistMissingStocks(MarketType.KOSPI, activeTickers)).willReturn(3);
+
+        StockMasterSyncUseCase.StockDelistResult result = service.markDelisted(
+                new StockMasterSyncUseCase.StockDelistCommand(MarketType.KOSPI, activeTickers)
+        );
+
+        assertThat(result.delistedCount()).isEqualTo(3);
+        verify(stockRepository).delistMissingStocks(MarketType.KOSPI, activeTickers);
+    }
+
+    private KospiItem kospiItem(String shortCode, String koreanName) {
+        KospiItem item = mock(KospiItem.class);
+        given(item.shortCode()).willReturn(shortCode);
+        given(item.isinCode()).willReturn("KR7" + shortCode.strip() + "0003");
+        given(item.koreanName()).willReturn(koreanName);
+        given(item.groupCode()).willReturn("ST");
+        given(item.marketCapSize()).willReturn("1");
+        given(item.sectorLarge()).willReturn("0001");
+        given(item.sectorMedium()).willReturn("0029");
+        given(item.sectorSmall()).willReturn("0000");
+        lenient().when(item.listingDate()).thenReturn("19750611");
+        given(item.parValue()).willReturn("000000000100");
+        given(item.fiscalMonth()).willReturn("12");
+        given(item.preferredStockType()).willReturn("0");
+        given(item.clearingTrade()).willReturn("N");
+        given(item.tradingHalt()).willReturn("N");
+        given(item.administeredStock()).willReturn("N");
+        given(item.marketWarningLevel()).willReturn("00");
+        given(item.warningNotice()).willReturn("N");
+        given(item.unfaithfulDisclosure()).willReturn("N");
+        given(item.backdoorListing()).willReturn("N");
+        given(item.shortTermOverheat()).willReturn("N");
+        given(item.shortSellOverheat()).willReturn("N");
+        given(item.abnormalSurge()).willReturn("N");
+        return item;
+    }
+
+    private KosdaqItem kosdaqItem(String shortCode, String koreanName) {
+        KosdaqItem item = mock(KosdaqItem.class);
+        given(item.shortCode()).willReturn(shortCode);
+        given(item.isinCode()).willReturn("KR7" + shortCode.strip() + "0001");
+        given(item.koreanName()).willReturn(koreanName);
+        given(item.groupCode()).willReturn("ST");
+        given(item.marketCapSize()).willReturn("1");
+        given(item.sectorLarge()).willReturn("0001");
+        given(item.sectorMedium()).willReturn("0027");
+        given(item.sectorSmall()).willReturn("0000");
+        given(item.listingDate()).willReturn("20001004");
+        given(item.parValue()).willReturn("000000000500");
+        given(item.fiscalMonth()).willReturn("12");
+        given(item.preferredStockType()).willReturn("0");
+        given(item.clearingTrade()).willReturn("N");
+        given(item.tradingHalt()).willReturn("N");
+        given(item.administeredStock()).willReturn("N");
+        given(item.marketWarningLevel()).willReturn("00");
+        given(item.warningNotice()).willReturn("N");
+        given(item.unfaithfulDisclosure()).willReturn("N");
+        given(item.backdoorListing()).willReturn("N");
+        given(item.shortTermOverheat()).willReturn("N");
+        given(item.shortSellOverheat()).willReturn("N");
+        given(item.abnormalSurge()).willReturn("N");
+        given(item.investCaution()).willReturn("N");
+        return item;
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/portfolio/PortfolioFacadeTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/portfolio/PortfolioFacadeTest.java
@@ -1,0 +1,189 @@
+package org.stockwellness.application.service.portfolio;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.stockwellness.application.port.in.portfolio.AiAdvisorUseCase;
+import org.stockwellness.application.port.in.portfolio.DiagnosePortfolioUseCase;
+import org.stockwellness.application.port.in.portfolio.LoadPortfolioUseCase;
+import org.stockwellness.application.port.in.portfolio.ManagePortfolioUseCase;
+import org.stockwellness.application.port.in.portfolio.PortfolioAnalysisUseCase;
+import org.stockwellness.application.port.in.portfolio.command.BacktestPortfolioCommand;
+import org.stockwellness.application.port.in.portfolio.command.CreatePortfolioCommand;
+import org.stockwellness.application.port.in.portfolio.command.UpdatePortfolioCommand;
+import org.stockwellness.application.port.in.portfolio.dto.PortfolioResponse;
+import org.stockwellness.application.port.in.portfolio.result.AdviceResponse;
+import org.stockwellness.application.port.in.portfolio.result.PortfolioAnalysisSummaryResult;
+import org.stockwellness.application.port.in.portfolio.result.PortfolioDiversificationResult;
+import org.stockwellness.application.port.in.portfolio.result.PortfolioHealthResult;
+import org.stockwellness.application.port.in.portfolio.result.PortfolioInceptionChartResult;
+import org.stockwellness.application.port.in.portfolio.result.PortfolioInceptionPerformanceResult;
+import org.stockwellness.application.port.in.portfolio.result.PortfolioRebalancingResult;
+import org.stockwellness.application.port.in.portfolio.result.PortfolioValuationResult;
+import org.stockwellness.application.service.portfolio.internal.BacktestResult;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PortfolioFacade 단위 테스트")
+class PortfolioFacadeTest {
+
+    @InjectMocks
+    private PortfolioFacade portfolioFacade;
+
+    @Mock
+    private ManagePortfolioUseCase managePortfolioUseCase;
+
+    @Mock
+    private LoadPortfolioUseCase loadPortfolioUseCase;
+
+    @Mock
+    private PortfolioAnalysisUseCase portfolioAnalysisUseCase;
+
+    @Mock
+    private DiagnosePortfolioUseCase diagnosePortfolioUseCase;
+
+    @Mock
+    private AiAdvisorUseCase aiAdvisorUseCase;
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long PORTFOLIO_ID = 100L;
+
+    @Test
+    @DisplayName("포트폴리오 관리 요청은 ManagePortfolioUseCase로 위임한다")
+    void delegateManageUseCase() {
+        CreatePortfolioCommand createCommand = mock(CreatePortfolioCommand.class);
+        UpdatePortfolioCommand updateCommand = mock(UpdatePortfolioCommand.class);
+        given(managePortfolioUseCase.createPortfolio(createCommand)).willReturn(PORTFOLIO_ID);
+
+        Long createdId = portfolioFacade.createPortfolio(createCommand);
+        portfolioFacade.updatePortfolio(updateCommand);
+        portfolioFacade.deletePortfolio(MEMBER_ID, PORTFOLIO_ID);
+
+        assertThat(createdId).isEqualTo(PORTFOLIO_ID);
+        verify(managePortfolioUseCase).createPortfolio(createCommand);
+        verify(managePortfolioUseCase).updatePortfolio(updateCommand);
+        verify(managePortfolioUseCase).deletePortfolio(MEMBER_ID, PORTFOLIO_ID);
+    }
+
+    @Test
+    @DisplayName("포트폴리오 조회 요청은 LoadPortfolioUseCase로 위임한다")
+    void delegateLoadUseCase() {
+        PortfolioResponse portfolio = mock(PortfolioResponse.class);
+        List<PortfolioResponse> portfolios = List.of(portfolio);
+        given(loadPortfolioUseCase.getMyPortfolios(MEMBER_ID)).willReturn(portfolios);
+        given(loadPortfolioUseCase.getPortfolio(MEMBER_ID, PORTFOLIO_ID)).willReturn(portfolio);
+
+        assertThat(portfolioFacade.getMyPortfolios(MEMBER_ID)).isSameAs(portfolios);
+        assertThat(portfolioFacade.getPortfolio(MEMBER_ID, PORTFOLIO_ID)).isSameAs(portfolio);
+        verify(loadPortfolioUseCase).getMyPortfolios(MEMBER_ID);
+        verify(loadPortfolioUseCase).getPortfolio(MEMBER_ID, PORTFOLIO_ID);
+    }
+
+    @Test
+    @DisplayName("포트폴리오 분석 요청은 PortfolioAnalysisUseCase로 위임한다")
+    void delegateAnalysisUseCase() {
+        PortfolioValuationResult valuation = mock(PortfolioValuationResult.class);
+        PortfolioDiversificationResult diversification = mock(PortfolioDiversificationResult.class);
+        PortfolioRebalancingResult rebalancing = mock(PortfolioRebalancingResult.class);
+        BacktestPortfolioCommand backtestCommand = mock(BacktestPortfolioCommand.class);
+        BacktestResult backtestResult = mock(BacktestResult.class);
+        Map<String, Map<String, BigDecimal>> correlation = Map.of("005930", Map.of("000660", BigDecimal.ONE));
+        PortfolioInceptionPerformanceResult performance = mock(PortfolioInceptionPerformanceResult.class);
+        PortfolioInceptionChartResult chart = mock(PortfolioInceptionChartResult.class);
+
+        given(portfolioAnalysisUseCase.getValuation(MEMBER_ID, PORTFOLIO_ID)).willReturn(valuation);
+        given(portfolioAnalysisUseCase.getDiversification(MEMBER_ID, PORTFOLIO_ID)).willReturn(diversification);
+        given(portfolioAnalysisUseCase.getRebalancingGuide(MEMBER_ID, PORTFOLIO_ID)).willReturn(rebalancing);
+        given(portfolioAnalysisUseCase.runBacktest(backtestCommand)).willReturn(backtestResult);
+        given(portfolioAnalysisUseCase.getCorrelationMatrix(MEMBER_ID, PORTFOLIO_ID)).willReturn(correlation);
+        given(portfolioAnalysisUseCase.getPerformanceSinceInception(MEMBER_ID, PORTFOLIO_ID)).willReturn(performance);
+        given(portfolioAnalysisUseCase.getInceptionChart(MEMBER_ID, PORTFOLIO_ID)).willReturn(chart);
+
+        assertThat(portfolioFacade.getValuation(MEMBER_ID, PORTFOLIO_ID)).isSameAs(valuation);
+        assertThat(portfolioFacade.getDiversification(MEMBER_ID, PORTFOLIO_ID)).isSameAs(diversification);
+        assertThat(portfolioFacade.getRebalancingGuide(MEMBER_ID, PORTFOLIO_ID)).isSameAs(rebalancing);
+        assertThat(portfolioFacade.runBacktest(backtestCommand)).isSameAs(backtestResult);
+        assertThat(portfolioFacade.getCorrelationMatrix(MEMBER_ID, PORTFOLIO_ID)).isSameAs(correlation);
+        assertThat(portfolioFacade.getPerformanceSinceInception(MEMBER_ID, PORTFOLIO_ID)).isSameAs(performance);
+        assertThat(portfolioFacade.getInceptionChart(MEMBER_ID, PORTFOLIO_ID)).isSameAs(chart);
+    }
+
+    @Test
+    @DisplayName("분석 요약 조회 시 날짜가 없으면 종료일은 오늘, 시작일은 12개월 전으로 보정한다")
+    void getAnalysisSummary_DefaultDateRange() {
+        PortfolioAnalysisSummaryResult summary = mock(PortfolioAnalysisSummaryResult.class);
+        given(portfolioAnalysisUseCase.getAnalysisSummary(
+                org.mockito.ArgumentMatchers.eq(MEMBER_ID),
+                org.mockito.ArgumentMatchers.eq(PORTFOLIO_ID),
+                org.mockito.ArgumentMatchers.any(LocalDate.class),
+                org.mockito.ArgumentMatchers.any(LocalDate.class)
+        )).willReturn(summary);
+
+        LocalDate beforeCall = LocalDate.now();
+        PortfolioAnalysisSummaryResult result = portfolioFacade.getAnalysisSummary(MEMBER_ID, PORTFOLIO_ID, null, null);
+        LocalDate afterCall = LocalDate.now();
+
+        ArgumentCaptor<LocalDate> startCaptor = ArgumentCaptor.forClass(LocalDate.class);
+        ArgumentCaptor<LocalDate> endCaptor = ArgumentCaptor.forClass(LocalDate.class);
+        verify(portfolioAnalysisUseCase).getAnalysisSummary(
+                org.mockito.ArgumentMatchers.eq(MEMBER_ID),
+                org.mockito.ArgumentMatchers.eq(PORTFOLIO_ID),
+                startCaptor.capture(),
+                endCaptor.capture()
+        );
+        assertThat(result).isSameAs(summary);
+        assertThat(endCaptor.getValue()).isBetween(beforeCall, afterCall);
+        assertThat(startCaptor.getValue()).isEqualTo(endCaptor.getValue().minusMonths(12));
+    }
+
+    @Test
+    @DisplayName("AI가 비활성화되면 진단과 조언은 Mock 응답을 반환하고 UseCase를 호출하지 않는다")
+    void returnMockResponsesWhenAiDisabled() {
+        ReflectionTestUtils.setField(portfolioFacade, "aiEnabled", false);
+
+        PortfolioHealthResult healthResult = portfolioFacade.diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID);
+        AdviceResponse latestAdvice = portfolioFacade.getLatestAdvice(MEMBER_ID, PORTFOLIO_ID);
+        AdviceResponse newAdvice = portfolioFacade.getNewAdvice(MEMBER_ID, PORTFOLIO_ID);
+
+        assertThat(healthResult.summary()).contains("Mock AI 진단");
+        assertThat(latestAdvice.content()).contains("Mock AI 조언");
+        assertThat(newAdvice.content()).contains("Mock AI 조언");
+        verifyNoInteractions(diagnosePortfolioUseCase, aiAdvisorUseCase);
+    }
+
+    @Test
+    @DisplayName("AI가 활성화되면 진단과 조언 요청은 각 UseCase로 위임한다")
+    void delegateAiUseCasesWhenAiEnabled() {
+        ReflectionTestUtils.setField(portfolioFacade, "aiEnabled", true);
+        PortfolioHealthResult healthResult = PortfolioHealthResult.mock();
+        AdviceResponse latestAdvice = AdviceResponse.mock();
+        AdviceResponse newAdvice = AdviceResponse.mock();
+        given(diagnosePortfolioUseCase.diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID)).willReturn(healthResult);
+        given(aiAdvisorUseCase.getLatestAdvice(MEMBER_ID, PORTFOLIO_ID)).willReturn(latestAdvice);
+        given(aiAdvisorUseCase.getNewAdvice(MEMBER_ID, PORTFOLIO_ID)).willReturn(newAdvice);
+
+        assertThat(portfolioFacade.diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID)).isSameAs(healthResult);
+        assertThat(portfolioFacade.getLatestAdvice(MEMBER_ID, PORTFOLIO_ID)).isSameAs(latestAdvice);
+        assertThat(portfolioFacade.getNewAdvice(MEMBER_ID, PORTFOLIO_ID)).isSameAs(newAdvice);
+        verify(diagnosePortfolioUseCase).diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID);
+        verify(aiAdvisorUseCase).getLatestAdvice(MEMBER_ID, PORTFOLIO_ID);
+        verify(aiAdvisorUseCase).getNewAdvice(MEMBER_ID, PORTFOLIO_ID);
+        verify(aiAdvisorUseCase, never()).generateBacktestAdvice(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/stock/MarketWeatherClassifierTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/stock/MarketWeatherClassifierTest.java
@@ -1,0 +1,112 @@
+package org.stockwellness.application.service.stock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.stockwellness.application.port.in.stock.result.MarketWeatherLevel;
+import org.stockwellness.application.port.in.stock.result.MarketWeatherReason;
+import org.stockwellness.application.port.in.stock.result.MarketWeatherResult;
+import org.stockwellness.application.port.out.stock.MarketBreadthSnapshot;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MarketWeatherClassifier 단위 테스트")
+class MarketWeatherClassifierTest {
+
+    @Mock
+    private MarketWeatherFactory marketWeatherFactory;
+
+    @InjectMocks
+    private MarketWeatherClassifier classifier;
+
+    @Test
+    @DisplayName("의존성 주입 확인")
+    void setup() {
+        assertThat(classifier).isNotNull();
+    }
+
+    @Test
+    @DisplayName("코스피 급락 및 변동성 확대 시 STORMY를 반환한다")
+    void classify_stormy() {
+        // Given
+        BigDecimal kospiRate = new BigDecimal("-2.0");
+        BigDecimal kosdaqRate = new BigDecimal("-0.5");
+        MarketBreadthSnapshot breadth = new MarketBreadthSnapshot(
+                370, 100, 200, 50, 20,
+                new BigDecimal("0.3"), // advance
+                new BigDecimal("0.6"), // decline
+                new BigDecimal("0.3")  // high volatility (> 0.22)
+        );
+        LocalDate date = LocalDate.of(2026, 4, 24);
+        MarketWeatherResult expected = new MarketWeatherResult(
+                MarketWeatherLevel.STORMY, "Message", "Description", MarketWeatherReason.VOLATILE_SELL_OFF, date);
+
+        given(marketWeatherFactory.create(eq(MarketWeatherLevel.STORMY), eq(MarketWeatherReason.VOLATILE_SELL_OFF), eq(date)))
+                .willReturn(expected);
+
+        // When
+        MarketWeatherResult result = classifier.classify(kospiRate, kosdaqRate, breadth, date);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+        verify(marketWeatherFactory).create(MarketWeatherLevel.STORMY, MarketWeatherReason.VOLATILE_SELL_OFF, date);
+    }
+
+    @Test
+    @DisplayName("지수 상승 및 상승 종목 확산 시 CLEAR를 반환한다")
+    void classify_clear() {
+        // Given
+        BigDecimal kospiRate = new BigDecimal("1.5");
+        BigDecimal kosdaqRate = new BigDecimal("1.0");
+        MarketBreadthSnapshot breadth = new MarketBreadthSnapshot(
+                330, 200, 100, 20, 10,
+                new BigDecimal("0.7"), // advance (> 0.62)
+                new BigDecimal("0.2"), // decline
+                new BigDecimal("0.1")  // high volatility (< 0.28)
+        );
+        LocalDate date = LocalDate.of(2026, 4, 24);
+        MarketWeatherResult expected = new MarketWeatherResult(
+                MarketWeatherLevel.CLEAR, "Message", "Description", MarketWeatherReason.BROAD_RALLY, date);
+
+        given(marketWeatherFactory.create(eq(MarketWeatherLevel.CLEAR), eq(MarketWeatherReason.BROAD_RALLY), eq(date)))
+                .willReturn(expected);
+
+        // When
+        MarketWeatherResult result = classifier.classify(kospiRate, kosdaqRate, breadth, date);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+        verify(marketWeatherFactory).create(MarketWeatherLevel.CLEAR, MarketWeatherReason.BROAD_RALLY, date);
+    }
+
+    @Test
+    @DisplayName("상승 종목 데이터(Breadth)가 없을 때 지수만으로 CLEAR를 판별한다")
+    void classify_index_only() {
+        // Given
+        BigDecimal kospiRate = new BigDecimal("1.2");
+        BigDecimal kosdaqRate = new BigDecimal("1.0");
+        LocalDate date = LocalDate.of(2026, 4, 24);
+        MarketWeatherResult expected = new MarketWeatherResult(
+                MarketWeatherLevel.CLEAR, "Message", "Description", MarketWeatherReason.INDEX_ONLY_RALLY, date);
+
+        given(marketWeatherFactory.create(eq(MarketWeatherLevel.CLEAR), eq(MarketWeatherReason.INDEX_ONLY_RALLY), eq(date)))
+                .willReturn(expected);
+
+        // When
+        MarketWeatherResult result = classifier.classify(kospiRate, kosdaqRate, null, date);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+        verify(marketWeatherFactory).create(MarketWeatherLevel.CLEAR, MarketWeatherReason.INDEX_ONLY_RALLY, date);
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/stock/StockAnalysisServiceTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/stock/StockAnalysisServiceTest.java
@@ -1,0 +1,138 @@
+package org.stockwellness.application.service.stock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.stockwellness.application.port.in.stock.command.StockAnalysisCommand;
+import org.stockwellness.application.port.in.stock.result.StockAnalysisResult;
+import org.stockwellness.application.port.out.stock.LlmClientPort;
+import org.stockwellness.application.port.out.stock.LoadTechnicalDataPort;
+import org.stockwellness.domain.stock.analysis.AiAnalysisContext;
+import org.stockwellness.domain.stock.analysis.AiReport;
+import org.stockwellness.domain.stock.analysis.CrossoverSignal;
+import org.stockwellness.domain.stock.analysis.InvestmentDecision;
+import org.stockwellness.domain.stock.analysis.TrendStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StockAnalysisService 단위 테스트")
+class StockAnalysisServiceTest {
+
+    @InjectMocks
+    private StockAnalysisService stockAnalysisService;
+
+    @Mock
+    private LoadTechnicalDataPort technicalDataPort;
+
+    @Mock
+    private LlmClientPort llmClientPort;
+
+    @Test
+    @DisplayName("종목 분석 요청 시 기술 컨텍스트를 로드하고 LLM 분석 결과를 반환한다")
+    void analyze_Success() {
+        StockAnalysisCommand command = new StockAnalysisCommand("005930");
+        AiAnalysisContext context = createContext("005930", TrendStatus.REGULAR);
+        AiReport report = new AiReport(
+                InvestmentDecision.BUY,
+                85,
+                "정배열 상승",
+                List.of("정배열", "RSI 안정", "거래량 증가"),
+                "상승 추세가 확인됩니다."
+        );
+        given(technicalDataPort.loadTechnicalContext("005930")).willReturn(context);
+        given(llmClientPort.generateInsight(anyString(), org.mockito.ArgumentMatchers.eq(context))).willReturn(report);
+
+        StockAnalysisResult result = stockAnalysisService.analyze(command);
+
+        assertThat(result.isinCode()).isEqualTo("005930");
+        assertThat(result.trendStatus()).isEqualTo(TrendStatus.REGULAR);
+        assertThat(result.report()).isSameAs(report);
+        assertThat(result.analyzedAt()).isNotNull();
+        verify(technicalDataPort).loadTechnicalContext("005930");
+        verify(llmClientPort).generateInsight(anyString(), org.mockito.ArgumentMatchers.eq(context));
+    }
+
+    @Test
+    @DisplayName("LLM 호출 시 서비스의 시스템 지시문과 기술 컨텍스트를 함께 전달한다")
+    void analyze_PassesSystemInstructionAndContext() {
+        StockAnalysisCommand command = new StockAnalysisCommand("000660");
+        AiAnalysisContext context = createContext("000660", TrendStatus.NEUTRAL);
+        AiReport report = AiReport.fallback();
+        given(technicalDataPort.loadTechnicalContext("000660")).willReturn(context);
+        given(llmClientPort.generateInsight(anyString(), org.mockito.ArgumentMatchers.eq(context))).willReturn(report);
+
+        stockAnalysisService.analyze(command);
+
+        ArgumentCaptor<String> instructionCaptor = ArgumentCaptor.forClass(String.class);
+        verify(llmClientPort).generateInsight(instructionCaptor.capture(), org.mockito.ArgumentMatchers.eq(context));
+        assertThat(instructionCaptor.getValue())
+                .contains("퀀트 트레이더")
+                .contains("JSON 포맷")
+                .contains("decision")
+                .contains("confidenceScore");
+    }
+
+    @Test
+    @DisplayName("기술 데이터 로드 실패 시 예외를 전파하고 LLM을 호출하지 않는다")
+    void analyze_PropagatesTechnicalDataFailure() {
+        StockAnalysisCommand command = new StockAnalysisCommand("005930");
+        RuntimeException exception = new IllegalStateException("기술 데이터 없음");
+        given(technicalDataPort.loadTechnicalContext("005930")).willThrow(exception);
+
+        assertThatThrownBy(() -> stockAnalysisService.analyze(command))
+                .isSameAs(exception);
+        verify(llmClientPort, never()).generateInsight(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("LLM 분석 실패 시 예외를 전파한다")
+    void analyze_PropagatesLlmFailure() {
+        StockAnalysisCommand command = new StockAnalysisCommand("005930");
+        AiAnalysisContext context = createContext("005930", TrendStatus.INVERSE);
+        RuntimeException exception = new IllegalStateException("LLM 장애");
+        given(technicalDataPort.loadTechnicalContext("005930")).willReturn(context);
+        given(llmClientPort.generateInsight(anyString(), org.mockito.ArgumentMatchers.eq(context))).willThrow(exception);
+
+        assertThatThrownBy(() -> stockAnalysisService.analyze(command))
+                .isSameAs(exception);
+    }
+
+    private AiAnalysisContext createContext(String isinCode, TrendStatus trendStatus) {
+        return new AiAnalysisContext(
+                isinCode,
+                LocalDate.of(2026, 4, 24),
+                new AiAnalysisContext.PriceSummary(
+                        BigDecimal.valueOf(80000),
+                        BigDecimal.valueOf(2.5),
+                        BigDecimal.valueOf(1_000_000)
+                ),
+                new AiAnalysisContext.TechnicalSignal(
+                        trendStatus,
+                        BigDecimal.valueOf(55),
+                        "중립",
+                        BigDecimal.valueOf(1.2),
+                        CrossoverSignal.NONE,
+                        BigDecimal.valueOf(79000),
+                        BigDecimal.valueOf(78000),
+                        BigDecimal.valueOf(76000),
+                        BigDecimal.valueOf(74000)
+                ),
+                new AiAnalysisContext.PortfolioRisk(false, 10.0)
+        );
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/stock/StockSearchServiceTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/stock/StockSearchServiceTest.java
@@ -1,0 +1,105 @@
+package org.stockwellness.application.service.stock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.stockwellness.application.port.out.stock.PopularSearchPort;
+import org.stockwellness.application.port.out.stock.SearchHistoryPort;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StockSearchService 단위 테스트")
+class StockSearchServiceTest {
+
+    @Mock
+    private SearchHistoryPort searchHistoryPort;
+
+    @Mock
+    private PopularSearchPort popularSearchPort;
+
+    @InjectMocks
+    private StockSearchService stockSearchService;
+
+    @Test
+    @DisplayName("검색 기록 저장 시 TTL(30일)이 설정된다")
+    void saveSearchHistory_with_ttl() {
+        // Given
+        Long memberId = 1L;
+        String keyword = "삼성전자";
+        Duration expectedTtl = Duration.ofDays(30);
+
+        // When
+        stockSearchService.saveSearchHistory(memberId, keyword);
+
+        // Then
+        verify(searchHistoryPort).save(memberId, keyword);
+        verify(searchHistoryPort).setExpireTime(memberId, expectedTtl);
+    }
+
+    @Test
+    @DisplayName("최근 검색어 목록을 조회한다")
+    void getRecentSearches() {
+        // Given
+        Long memberId = 1L;
+        List<String> expected = List.of("삼성전자", "Apple");
+        given(searchHistoryPort.findAll(memberId)).willReturn(expected);
+
+        // When
+        List<String> result = stockSearchService.getRecentSearches(memberId);
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+        verify(searchHistoryPort).findAll(memberId);
+    }
+
+    @Test
+    @DisplayName("특정 검색 기록을 삭제한다")
+    void removeSearchHistory() {
+        // Given
+        Long memberId = 1L;
+        String keyword = "삼성전자";
+
+        // When
+        stockSearchService.removeSearchHistory(memberId, keyword);
+
+        // Then
+        verify(searchHistoryPort).delete(memberId, keyword);
+    }
+
+    @Test
+    @DisplayName("전체 검색 기록을 삭제한다")
+    void clearSearchHistory() {
+        // Given
+        Long memberId = 1L;
+
+        // When
+        stockSearchService.clearSearchHistory(memberId);
+
+        // Then
+        verify(searchHistoryPort).deleteAll(memberId);
+    }
+
+    @Test
+    @DisplayName("인기 검색어 10개를 조회한다")
+    void getPopularSearches() {
+        // Given
+        List<String> expected = List.of("삼성전자", "SK하이닉스");
+        given(popularSearchPort.findTop10()).willReturn(expected);
+
+        // When
+        List<String> result = stockSearchService.getPopularSearches();
+
+        // Then
+        assertThat(result).isEqualTo(expected);
+        verify(popularSearchPort).findTop10();
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/stock/StockServiceTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/stock/StockServiceTest.java
@@ -1,0 +1,122 @@
+package org.stockwellness.application.service.stock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Slice;
+import org.stockwellness.adapter.out.persistence.stock.repository.StockRepository;
+import org.stockwellness.application.port.in.stock.query.SearchStockQuery;
+import org.stockwellness.application.port.in.stock.result.StockDetailResult;
+import org.stockwellness.application.port.in.stock.result.StockSearchResult;
+import org.stockwellness.application.port.out.stock.StockPricePort;
+import org.stockwellness.domain.stock.Currency;
+import org.stockwellness.domain.stock.MarketType;
+import org.stockwellness.domain.stock.Stock;
+import org.stockwellness.domain.stock.StockSector;
+import org.stockwellness.domain.stock.StockStatus;
+import org.stockwellness.domain.stock.event.StockSearchEvent;
+import org.stockwellness.domain.stock.price.StockPrice;
+import org.stockwellness.domain.stock.price.TechnicalIndicators;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StockService 단위 테스트")
+class StockServiceTest {
+
+    @Mock
+    private StockRepository stockRepository;
+
+    @Mock
+    private StockPricePort stockPricePort;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private StockService stockService;
+
+    @Test
+    @DisplayName("종목 상세 조회 시 시세 정보가 있으면 변동률이 정확히 계산된다")
+    void getStockDetail_with_price() {
+        // Given
+        String ticker = "005930";
+        StockSector sector = StockSector.of(null, null, null, "Information Technology");
+        Stock stock = Stock.of(ticker, "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, sector, StockStatus.ACTIVE);
+
+        TechnicalIndicators indicators = new TechnicalIndicators(
+                null, BigDecimal.valueOf(75000), null, null, BigDecimal.valueOf(60),
+                null, null, null, null, null, null, null, null,
+                null, null, null, null, "상승 추세"
+        );
+
+        StockPrice price = StockPrice.of(
+                stock, LocalDate.of(2026, 4, 24),
+                BigDecimal.valueOf(79000), BigDecimal.valueOf(81000), BigDecimal.valueOf(78500),
+                BigDecimal.valueOf(80000), BigDecimal.valueOf(80000), BigDecimal.valueOf(78000),
+                1000000L, BigDecimal.valueOf(80000000000L), indicators
+        );
+
+        given(stockRepository.findByTicker(ticker)).willReturn(Optional.of(stock));
+        given(stockPricePort.findLatestByTicker(ticker)).willReturn(Optional.of(price));
+
+        // When
+        StockDetailResult result = stockService.getStockDetail(ticker);
+
+        // Then
+        assertThat(result.ticker()).isEqualTo(ticker);
+        assertThat(result.currentPrice()).isEqualByComparingTo(BigDecimal.valueOf(80000));
+        assertThat(result.priceChange()).isEqualByComparingTo(BigDecimal.valueOf(2000));
+        assertThat(result.fluctuationRate()).isEqualByComparingTo(new BigDecimal("2.5600")); // (2000/78000) -> 0.0256 * 100
+        assertThat(result.rsi14()).isEqualByComparingTo(BigDecimal.valueOf(60));
+        assertThat(result.aiInsight()).isEqualTo("상승 추세");
+    }
+
+    @Test
+    @DisplayName("종목 상세 조회 시 시세 정보가 없으면 기본값으로 반환한다")
+    void getStockDetail_without_price() {
+        // Given
+        String ticker = "005930";
+        StockSector sector = StockSector.of(null, null, null, "Information Technology");
+        Stock stock = Stock.of(ticker, "KR7005930003", "삼성전자", MarketType.KOSPI, Currency.KRW, sector, StockStatus.ACTIVE);
+
+        given(stockRepository.findByTicker(ticker)).willReturn(Optional.of(stock));
+        given(stockPricePort.findLatestByTicker(ticker)).willReturn(Optional.empty());
+
+        // When
+        StockDetailResult result = stockService.getStockDetail(ticker);
+
+        // Then
+        assertThat(result.currentPrice()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(result.fluctuationRate()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(result.aiInsight()).isEqualTo("데이터 집계 중입니다.");
+    }
+
+    @Test
+    @DisplayName("종목 검색 시 검색 이벤트가 발행된다")
+    void searchStocks_publishes_event() {
+        // Given
+        SearchStockQuery query = new SearchStockQuery("삼성", null, null, null, null, 0, 10);
+        given(stockRepository.searchByCondition(any(), any(), any(), any(), any(), any()))
+                .willReturn(new PageImpl<>(List.of()));
+
+        // When
+        Slice<StockSearchResult> result = stockService.searchStocks(query);
+
+        // Then
+        verify(eventPublisher).publishEvent(any(StockSearchEvent.class));
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/watchlist/WatchlistServiceDataTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/watchlist/WatchlistServiceDataTest.java
@@ -1,0 +1,79 @@
+package org.stockwellness.application.service.watchlist;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.stockwellness.application.port.in.watchlist.dto.WatchlistItemListResponse;
+import org.stockwellness.application.port.out.watchlist.StockDataPort;
+import org.stockwellness.application.port.out.watchlist.WatchlistPort;
+import org.stockwellness.domain.member.LoginType;
+import org.stockwellness.domain.member.Member;
+import org.stockwellness.domain.stock.Currency;
+import org.stockwellness.domain.stock.MarketType;
+import org.stockwellness.domain.stock.Stock;
+import org.stockwellness.domain.stock.StockStatus;
+import org.stockwellness.domain.watchlist.WatchlistGroup;
+import org.stockwellness.domain.watchlist.WatchlistItem;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WatchlistServiceDataTest {
+
+    @InjectMocks
+    private WatchlistService watchlistService;
+
+    @Mock
+    private WatchlistPort watchlistPort;
+    @Mock
+    private StockDataPort stockDataPort;
+
+    @Test
+    void getItems가_상세_데이터를_포함하여_반환한다() {
+        // given
+        Long memberId = 1L;
+        Long groupId = 1L;
+        Member member = Member.register("test@test.com", "tester", LoginType.GOOGLE);
+        ReflectionTestUtils.setField(member, "id", memberId);
+        
+        WatchlistGroup group = WatchlistGroup.create(member, "테스트 그룹");
+        ReflectionTestUtils.setField(group, "id", groupId);
+
+        Stock stock = Stock.of("000660", "KR7000660001", "SK하이닉스", MarketType.KOSPI, Currency.KRW, null, StockStatus.ACTIVE);
+        ReflectionTestUtils.setField(stock, "id", 100L);
+
+        WatchlistItem item = WatchlistItem.create(group, stock);
+        
+        given(watchlistPort.findGroupById(groupId)).willReturn(Optional.of(group));
+        given(watchlistPort.findItemsWithStock(group)).willReturn(List.of(item));
+        
+        StockDataPort.StockWellnessDetail detail = new StockDataPort.StockWellnessDetail(
+                "KR7000660001",
+                new BigDecimal("180000"),
+                new BigDecimal("2.5"),
+                new BigDecimal("65.0"),
+                "중립",
+                "정배열 추세"
+        );
+        given(stockDataPort.getStockDetails(any())).willReturn(Map.of("KR7000660001", detail));
+
+        // when
+        WatchlistItemListResponse response = watchlistService.getItems(memberId, groupId);
+
+        // then
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.items().get(0).currentPrice()).isEqualByComparingTo("180000");
+        assertThat(response.items().get(0).rsiStatus()).isEqualTo("중립");
+        assertThat(response.items().get(0).aiInsight()).isEqualTo("정배열 추세");
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/domain/portfolio/diagnosis/type/AttackScorePolicyTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/domain/portfolio/diagnosis/type/AttackScorePolicyTest.java
@@ -1,0 +1,38 @@
+package org.stockwellness.domain.portfolio.diagnosis.type;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AttackScorePolicyTest {
+
+    @Test
+    @DisplayName("RSI 범위와 MACD 방향에 따라 올바른 공격력 점수를 산출한다")
+    void shouldCalculateAttackScoreBasedOnRsiAndMacd() {
+        // STRONG_BUY (RSI >= 70)
+        assertThat(AttackScorePolicy.calculate(new BigDecimal("70"), new BigDecimal("1"))).isEqualTo(100); // 90 + 10
+        assertThat(AttackScorePolicy.calculate(new BigDecimal("70"), new BigDecimal("-1"))).isEqualTo(90);
+
+        // BUY (50 <= RSI < 70)
+        assertThat(AttackScorePolicy.calculate(new BigDecimal("50"), new BigDecimal("1"))).isEqualTo(80); // 70 + 10
+        assertThat(AttackScorePolicy.calculate(new BigDecimal("50"), new BigDecimal("-1"))).isEqualTo(70);
+
+        // NEUTRAL (RSI < 50)
+        assertThat(AttackScorePolicy.calculate(new BigDecimal("49"), new BigDecimal("1"))).isEqualTo(50); // 40 + 10
+        assertThat(AttackScorePolicy.calculate(new BigDecimal("49"), new BigDecimal("-1"))).isEqualTo(40);
+    }
+
+    @Test
+    @DisplayName("입력값이 Null이면 기본 점수 50점을 반환한다")
+    void shouldReturnDefaultScoreWhenInputIsNull() {
+        assertThat(AttackScorePolicy.calculate(null, new BigDecimal("1"))).isEqualTo(50);
+        assertThat(AttackScorePolicy.calculate(new BigDecimal("70"), null)).isEqualTo(50);
+    }
+
+    @Test
+    @DisplayName("MACD가 정확히 0이면 보너스 점수를 부여한다")
+    void shouldApplyBonusWhenMacdIsZero() {
+        assertThat(AttackScorePolicy.calculate(new BigDecimal("50"), BigDecimal.ZERO)).isEqualTo(80);
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/domain/portfolio/diagnosis/type/DefenseScorePolicyTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/domain/portfolio/diagnosis/type/DefenseScorePolicyTest.java
@@ -1,0 +1,34 @@
+package org.stockwellness.domain.portfolio.diagnosis.type;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefenseScorePolicyTest {
+
+    @Test
+    @DisplayName("시가총액 규모에 따라 올바른 방어력 점수를 산출한다")
+    void shouldCalculateDefenseScoreBasedOnMarketCap() {
+        // MEGA_CAP (>= 20조)
+        assertThat(DefenseScorePolicy.calculate(new BigDecimal("20000000000000"))).isEqualTo(100);
+        
+        // LARGE_CAP (>= 5조)
+        assertThat(DefenseScorePolicy.calculate(new BigDecimal("5000000000000"))).isEqualTo(80);
+        assertThat(DefenseScorePolicy.calculate(new BigDecimal("19999999999999"))).isEqualTo(80);
+
+        // MID_CAP (>= 1조)
+        assertThat(DefenseScorePolicy.calculate(new BigDecimal("1000000000000"))).isEqualTo(60);
+        assertThat(DefenseScorePolicy.calculate(new BigDecimal("4999999999999"))).isEqualTo(60);
+
+        // SMALL_CAP (< 1조)
+        assertThat(DefenseScorePolicy.calculate(new BigDecimal("999999999999"))).isEqualTo(40);
+        assertThat(DefenseScorePolicy.calculate(new BigDecimal("0"))).isEqualTo(40);
+    }
+
+    @Test
+    @DisplayName("입력값이 Null이면 기본 점수 50점을 반환한다")
+    void shouldReturnDefaultScoreWhenInputIsNull() {
+        assertThat(DefenseScorePolicy.calculate(null)).isEqualTo(50);
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/domain/portfolio/diagnosis/type/EnduranceScorePolicyTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/domain/portfolio/diagnosis/type/EnduranceScorePolicyTest.java
@@ -1,0 +1,34 @@
+package org.stockwellness.domain.portfolio.diagnosis.type;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnduranceScorePolicyTest {
+
+    @Test
+    @DisplayName("입력값이 Null이거나 이동평균선이 0이면 기본 점수 50점을 반환한다")
+    void shouldReturnDefaultScoreWhenInputIsInvalid() {
+        assertThat(EnduranceScorePolicy.calculate(null, new BigDecimal("100"))).isEqualTo(50);
+        assertThat(EnduranceScorePolicy.calculate(new BigDecimal("100"), null)).isEqualTo(50);
+        assertThat(EnduranceScorePolicy.calculate(new BigDecimal("100"), BigDecimal.ZERO)).isEqualTo(50);
+    }
+
+    @Test
+    @DisplayName("이격도에 따라 올바른 인내심 점수를 산출한다")
+    void shouldCalculateEnduranceScoreBasedOnDisparity() {
+        // OPTIMAL (100% ~ 110%)
+        assertThat(EnduranceScorePolicy.calculate(new BigDecimal("100"), new BigDecimal("100"))).isEqualTo(100);
+        assertThat(EnduranceScorePolicy.calculate(new BigDecimal("105"), new BigDecimal("100"))).isEqualTo(100);
+        assertThat(EnduranceScorePolicy.calculate(new BigDecimal("110"), new BigDecimal("100"))).isEqualTo(100);
+
+        // OVERHEATED (> 110%)
+        assertThat(EnduranceScorePolicy.calculate(new BigDecimal("111"), new BigDecimal("100"))).isEqualTo(70);
+        assertThat(EnduranceScorePolicy.calculate(new BigDecimal("150"), new BigDecimal("100"))).isEqualTo(70);
+
+        // UNDERVALUED (< 100%)
+        assertThat(EnduranceScorePolicy.calculate(new BigDecimal("99"), new BigDecimal("100"))).isEqualTo(40);
+        assertThat(EnduranceScorePolicy.calculate(new BigDecimal("50"), new BigDecimal("100"))).isEqualTo(40);
+    }
+}

--- a/stockwellness-core/src/test/java/org/stockwellness/domain/stock/analysis/TechnicalScoreServiceTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/domain/stock/analysis/TechnicalScoreServiceTest.java
@@ -1,0 +1,147 @@
+package org.stockwellness.domain.stock.analysis;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.stockwellness.domain.stock.price.AlignmentStatus;
+import org.stockwellness.domain.stock.price.TechnicalIndicators;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("TechnicalScoreService 단위 테스트")
+class TechnicalScoreServiceTest {
+
+    private final TechnicalScoreService technicalScoreService = new TechnicalScoreService(List.of(
+            new BasicScoringPolicies.AlignmentPolicy(),
+            new BasicScoringPolicies.RsiPolicy(),
+            new BasicScoringPolicies.EventPolicy(),
+            new BasicScoringPolicies.BollingerPolicy()
+    ));
+
+    @Test
+    @DisplayName("매수 신호 조합은 정책 점수를 합산해 100점으로 제한한다")
+    void calculateScore_BuySignals_ClampsToMaximum() {
+        TechnicalScoreService.IndicatorSnapshot snapshot = new TechnicalScoreService.IndicatorSnapshot(
+                AlignmentStatus.PERFECT,
+                BigDecimal.ZERO,
+                BigDecimal.valueOf(25),
+                true,
+                false,
+                BigDecimal.valueOf(90),
+                BigDecimal.valueOf(90),
+                BigDecimal.valueOf(120)
+        );
+
+        int score = technicalScoreService.calculateScore(snapshot);
+
+        assertThat(score).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("매도 신호 조합은 정책 점수를 합산해 0점으로 제한한다")
+    void calculateScore_SellSignals_ClampsToMinimum() {
+        TechnicalScoreService.IndicatorSnapshot snapshot = new TechnicalScoreService.IndicatorSnapshot(
+                AlignmentStatus.REVERSE,
+                BigDecimal.valueOf(100),
+                BigDecimal.valueOf(25),
+                false,
+                true,
+                BigDecimal.valueOf(130),
+                BigDecimal.valueOf(90),
+                BigDecimal.valueOf(130)
+        );
+
+        int score = technicalScoreService.calculateScore(snapshot);
+
+        assertThat(score).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("RSI 경계값 0과 100은 각각 과매도와 과매수 점수로 반영한다")
+    void calculateScore_RsiExtremeBoundaries() {
+        TechnicalScoreService onlyRsiService = new TechnicalScoreService(List.of(new BasicScoringPolicies.RsiPolicy()));
+        TechnicalScoreService.IndicatorSnapshot oversold = new TechnicalScoreService.IndicatorSnapshot(
+                AlignmentStatus.MIXED,
+                BigDecimal.ZERO,
+                null,
+                false,
+                false,
+                null,
+                null,
+                null
+        );
+        TechnicalScoreService.IndicatorSnapshot overbought = new TechnicalScoreService.IndicatorSnapshot(
+                AlignmentStatus.MIXED,
+                BigDecimal.valueOf(100),
+                null,
+                false,
+                false,
+                null,
+                null,
+                null
+        );
+
+        assertThat(onlyRsiService.calculateScore(oversold)).isEqualTo(65);
+        assertThat(onlyRsiService.calculateScore(overbought)).isEqualTo(35);
+    }
+
+    @Test
+    @DisplayName("중립 지표는 기본 점수 50점을 유지한다")
+    void calculateScore_NeutralSignals() {
+        TechnicalScoreService.IndicatorSnapshot snapshot = new TechnicalScoreService.IndicatorSnapshot(
+                AlignmentStatus.MIXED,
+                BigDecimal.valueOf(50),
+                null,
+                false,
+                false,
+                BigDecimal.valueOf(100),
+                BigDecimal.valueOf(90),
+                BigDecimal.valueOf(110)
+        );
+
+        int score = technicalScoreService.calculateScore(snapshot);
+
+        assertThat(score).isEqualTo(50);
+    }
+
+    @Test
+    @DisplayName("IndicatorSnapshot.from은 TechnicalIndicators 필드를 null-safe하게 변환한다")
+    void indicatorSnapshotFrom_MapsTechnicalIndicators() {
+        TechnicalIndicators indicators = new TechnicalIndicators(
+                BigDecimal.valueOf(5),
+                BigDecimal.valueOf(20),
+                BigDecimal.valueOf(60),
+                BigDecimal.valueOf(120),
+                BigDecimal.valueOf(29),
+                BigDecimal.valueOf(1.5),
+                BigDecimal.valueOf(1.2),
+                BigDecimal.valueOf(110),
+                BigDecimal.valueOf(100),
+                BigDecimal.valueOf(90),
+                BigDecimal.valueOf(18),
+                BigDecimal.valueOf(30),
+                BigDecimal.valueOf(20),
+                AlignmentStatus.PERFECT,
+                true,
+                null,
+                true,
+                "상승 추세"
+        );
+
+        TechnicalScoreService.IndicatorSnapshot snapshot = TechnicalScoreService.IndicatorSnapshot.from(
+                indicators,
+                BigDecimal.valueOf(95)
+        );
+
+        assertThat(snapshot.alignment()).isEqualTo(AlignmentStatus.PERFECT);
+        assertThat(snapshot.rsi()).isEqualByComparingTo("29");
+        assertThat(snapshot.adx()).isEqualByComparingTo("18");
+        assertThat(snapshot.isGoldenCross()).isTrue();
+        assertThat(snapshot.isDeadCross()).isFalse();
+        assertThat(snapshot.closePrice()).isEqualByComparingTo("95");
+        assertThat(snapshot.bbLower()).isEqualByComparingTo("90");
+        assertThat(snapshot.bbUpper()).isEqualByComparingTo("110");
+    }
+}


### PR DESCRIPTION
## 요약
- EnduranceScorePolicy, AttackScorePolicy, DefenseScorePolicy 클래스에 대한 단위 테스트 구현
- 이격도, RSI, MACD, 시가총액 등 각 정책별 경계값 및 엣지 케이스 검증
- 순수 JUnit 5 기반의 독립적인 도메인 로직 테스트로 100% 브랜치 커버리지 확보

## 테스트 계획
- [x] EnduranceScorePolicyTest 실행 (이격도 구간별 점수 확인)
- [x] AttackScorePolicyTest 실행 (RSI 및 MACD 보너스 확인)
- [x] DefenseScorePolicyTest 실행 (시가총액 규모별 점수 확인)
- [x] 전체 정책 테스트 통합 실행 (./gradlew :stockwellness-core:test)

Closes #238