### PR TITLE
test(core): PortfolioFacade 테스트 구조 리팩토링 및 시나리오 보강 (#233)

### DIFF
--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/portfolio/PortfolioFacadeTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/portfolio/PortfolioFacadeTest.java
@@ -164,6 +164,52 @@ class PortfolioFacadeTest {
             assertThat(endCaptor.getValue()).isBetween(beforeCall, afterCall);
             assertThat(startCaptor.getValue()).isEqualTo(endCaptor.getValue().minusMonths(12));
         }
+
+        @Test
+        @DisplayName("시작일만 있는 경우 종료일은 오늘로 보정한다")
+        void getAnalysisSummary_OnlyStartDate() {
+            PortfolioAnalysisSummaryResult summary = mock(PortfolioAnalysisSummaryResult.class);
+            LocalDate startDate = LocalDate.of(2023, 1, 1);
+            given(portfolioAnalysisUseCase.getAnalysisSummary(
+                    eq(MEMBER_ID),
+                    eq(PORTFOLIO_ID),
+                    eq(startDate),
+                    any(LocalDate.class)
+            )).willReturn(summary);
+
+            LocalDate beforeCall = LocalDate.now();
+            PortfolioAnalysisSummaryResult result = portfolioFacade.getAnalysisSummary(MEMBER_ID, PORTFOLIO_ID, startDate, null);
+            LocalDate afterCall = LocalDate.now();
+
+            ArgumentCaptor<LocalDate> endCaptor = ArgumentCaptor.forClass(LocalDate.class);
+            verify(portfolioAnalysisUseCase).getAnalysisSummary(
+                    eq(MEMBER_ID),
+                    eq(PORTFOLIO_ID),
+                    eq(startDate),
+                    endCaptor.capture()
+            );
+            assertThat(result).isSameAs(summary);
+            assertThat(endCaptor.getValue()).isBetween(beforeCall, afterCall);
+        }
+
+        @Test
+        @DisplayName("종료일만 있는 경우 시작일은 종료일 기준 12개월 전으로 보정한다")
+        void getAnalysisSummary_OnlyEndDate() {
+            PortfolioAnalysisSummaryResult summary = mock(PortfolioAnalysisSummaryResult.class);
+            LocalDate endDate = LocalDate.of(2023, 12, 31);
+            LocalDate expectedStartDate = endDate.minusMonths(12);
+            given(portfolioAnalysisUseCase.getAnalysisSummary(
+                    MEMBER_ID,
+                    PORTFOLIO_ID,
+                    expectedStartDate,
+                    endDate
+            )).willReturn(summary);
+
+            PortfolioAnalysisSummaryResult result = portfolioFacade.getAnalysisSummary(MEMBER_ID, PORTFOLIO_ID, null, endDate);
+
+            assertThat(result).isSameAs(summary);
+            verify(portfolioAnalysisUseCase).getAnalysisSummary(MEMBER_ID, PORTFOLIO_ID, expectedStartDate, endDate);
+        }
     }
 
     @Nested

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/portfolio/PortfolioFacadeTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/portfolio/PortfolioFacadeTest.java
@@ -18,14 +18,7 @@ import org.stockwellness.application.port.in.portfolio.command.BacktestPortfolio
 import org.stockwellness.application.port.in.portfolio.command.CreatePortfolioCommand;
 import org.stockwellness.application.port.in.portfolio.command.UpdatePortfolioCommand;
 import org.stockwellness.application.port.in.portfolio.dto.PortfolioResponse;
-import org.stockwellness.application.port.in.portfolio.result.AdviceResponse;
-import org.stockwellness.application.port.in.portfolio.result.PortfolioAnalysisSummaryResult;
-import org.stockwellness.application.port.in.portfolio.result.PortfolioDiversificationResult;
-import org.stockwellness.application.port.in.portfolio.result.PortfolioHealthResult;
-import org.stockwellness.application.port.in.portfolio.result.PortfolioInceptionChartResult;
-import org.stockwellness.application.port.in.portfolio.result.PortfolioInceptionPerformanceResult;
-import org.stockwellness.application.port.in.portfolio.result.PortfolioRebalancingResult;
-import org.stockwellness.application.port.in.portfolio.result.PortfolioValuationResult;
+import org.stockwellness.application.port.in.portfolio.result.*;
 import org.stockwellness.application.service.portfolio.internal.BacktestResult;
 
 import java.math.BigDecimal;
@@ -35,13 +28,9 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PortfolioFacade 단위 테스트")
@@ -199,10 +188,10 @@ class PortfolioFacadeTest {
             LocalDate endDate = LocalDate.of(2023, 12, 31);
             LocalDate expectedStartDate = endDate.minusMonths(12);
             given(portfolioAnalysisUseCase.getAnalysisSummary(
-                    MEMBER_ID,
-                    PORTFOLIO_ID,
-                    expectedStartDate,
-                    endDate
+                    eq(MEMBER_ID),
+                    eq(PORTFOLIO_ID),
+                    eq(expectedStartDate),
+                    eq(endDate)
             )).willReturn(summary);
 
             PortfolioAnalysisSummaryResult result = portfolioFacade.getAnalysisSummary(MEMBER_ID, PORTFOLIO_ID, null, endDate);
@@ -255,5 +244,19 @@ class PortfolioFacadeTest {
     @Nested
     @DisplayName("예외 전파 테스트")
     class ExceptionTests {
+
+        @Test
+        @DisplayName("UseCase에서 발생한 예외는 Facade에서 그대로 전파되어야 한다")
+        void propagateExceptionFromUseCase() {
+            // given
+            CreatePortfolioCommand command = mock(CreatePortfolioCommand.class);
+            String errorMessage = "Domain Error";
+            given(managePortfolioUseCase.createPortfolio(any())).willThrow(new RuntimeException(errorMessage));
+
+            // when & then
+            assertThatThrownBy(() -> portfolioFacade.createPortfolio(command))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage(errorMessage);
+        }
     }
 }

--- a/stockwellness-core/src/test/java/org/stockwellness/application/service/portfolio/PortfolioFacadeTest.java
+++ b/stockwellness-core/src/test/java/org/stockwellness/application/service/portfolio/PortfolioFacadeTest.java
@@ -1,6 +1,7 @@
 package org.stockwellness.application.service.portfolio;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -33,6 +34,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -64,126 +68,146 @@ class PortfolioFacadeTest {
     private static final Long MEMBER_ID = 1L;
     private static final Long PORTFOLIO_ID = 100L;
 
-    @Test
-    @DisplayName("포트폴리오 관리 요청은 ManagePortfolioUseCase로 위임한다")
-    void delegateManageUseCase() {
-        CreatePortfolioCommand createCommand = mock(CreatePortfolioCommand.class);
-        UpdatePortfolioCommand updateCommand = mock(UpdatePortfolioCommand.class);
-        given(managePortfolioUseCase.createPortfolio(createCommand)).willReturn(PORTFOLIO_ID);
+    @Nested
+    @DisplayName("기본 위임 테스트")
+    class DelegationTests {
 
-        Long createdId = portfolioFacade.createPortfolio(createCommand);
-        portfolioFacade.updatePortfolio(updateCommand);
-        portfolioFacade.deletePortfolio(MEMBER_ID, PORTFOLIO_ID);
+        @Test
+        @DisplayName("포트폴리오 관리 요청은 ManagePortfolioUseCase로 위임한다")
+        void delegateManageUseCase() {
+            CreatePortfolioCommand createCommand = mock(CreatePortfolioCommand.class);
+            UpdatePortfolioCommand updateCommand = mock(UpdatePortfolioCommand.class);
+            given(managePortfolioUseCase.createPortfolio(createCommand)).willReturn(PORTFOLIO_ID);
 
-        assertThat(createdId).isEqualTo(PORTFOLIO_ID);
-        verify(managePortfolioUseCase).createPortfolio(createCommand);
-        verify(managePortfolioUseCase).updatePortfolio(updateCommand);
-        verify(managePortfolioUseCase).deletePortfolio(MEMBER_ID, PORTFOLIO_ID);
+            Long createdId = portfolioFacade.createPortfolio(createCommand);
+            portfolioFacade.updatePortfolio(updateCommand);
+            portfolioFacade.deletePortfolio(MEMBER_ID, PORTFOLIO_ID);
+
+            assertThat(createdId).isEqualTo(PORTFOLIO_ID);
+            verify(managePortfolioUseCase).createPortfolio(createCommand);
+            verify(managePortfolioUseCase).updatePortfolio(updateCommand);
+            verify(managePortfolioUseCase).deletePortfolio(MEMBER_ID, PORTFOLIO_ID);
+        }
+
+        @Test
+        @DisplayName("포트폴리오 조회 요청은 LoadPortfolioUseCase로 위임한다")
+        void delegateLoadUseCase() {
+            PortfolioResponse portfolio = mock(PortfolioResponse.class);
+            List<PortfolioResponse> portfolios = List.of(portfolio);
+            given(loadPortfolioUseCase.getMyPortfolios(MEMBER_ID)).willReturn(portfolios);
+            given(loadPortfolioUseCase.getPortfolio(MEMBER_ID, PORTFOLIO_ID)).willReturn(portfolio);
+
+            assertThat(portfolioFacade.getMyPortfolios(MEMBER_ID)).isSameAs(portfolios);
+            assertThat(portfolioFacade.getPortfolio(MEMBER_ID, PORTFOLIO_ID)).isSameAs(portfolio);
+            verify(loadPortfolioUseCase).getMyPortfolios(MEMBER_ID);
+            verify(loadPortfolioUseCase).getPortfolio(MEMBER_ID, PORTFOLIO_ID);
+        }
+
+        @Test
+        @DisplayName("포트폴리오 분석 요청은 PortfolioAnalysisUseCase로 위임한다")
+        void delegateAnalysisUseCase() {
+            PortfolioValuationResult valuation = mock(PortfolioValuationResult.class);
+            PortfolioDiversificationResult diversification = mock(PortfolioDiversificationResult.class);
+            PortfolioRebalancingResult rebalancing = mock(PortfolioRebalancingResult.class);
+            BacktestPortfolioCommand backtestCommand = mock(BacktestPortfolioCommand.class);
+            BacktestResult backtestResult = mock(BacktestResult.class);
+            Map<String, Map<String, BigDecimal>> correlation = Map.of("005930", Map.of("000660", BigDecimal.ONE));
+            PortfolioInceptionPerformanceResult performance = mock(PortfolioInceptionPerformanceResult.class);
+            PortfolioInceptionChartResult chart = mock(PortfolioInceptionChartResult.class);
+
+            given(portfolioAnalysisUseCase.getValuation(MEMBER_ID, PORTFOLIO_ID)).willReturn(valuation);
+            given(portfolioAnalysisUseCase.getDiversification(MEMBER_ID, PORTFOLIO_ID)).willReturn(diversification);
+            given(portfolioAnalysisUseCase.getRebalancingGuide(MEMBER_ID, PORTFOLIO_ID)).willReturn(rebalancing);
+            given(portfolioAnalysisUseCase.runBacktest(backtestCommand)).willReturn(backtestResult);
+            given(portfolioAnalysisUseCase.getCorrelationMatrix(MEMBER_ID, PORTFOLIO_ID)).willReturn(correlation);
+            given(portfolioAnalysisUseCase.getPerformanceSinceInception(MEMBER_ID, PORTFOLIO_ID)).willReturn(performance);
+            given(portfolioAnalysisUseCase.getInceptionChart(MEMBER_ID, PORTFOLIO_ID)).willReturn(chart);
+
+            assertThat(portfolioFacade.getValuation(MEMBER_ID, PORTFOLIO_ID)).isSameAs(valuation);
+            assertThat(portfolioFacade.getDiversification(MEMBER_ID, PORTFOLIO_ID)).isSameAs(diversification);
+            assertThat(portfolioFacade.getRebalancingGuide(MEMBER_ID, PORTFOLIO_ID)).isSameAs(rebalancing);
+            assertThat(portfolioFacade.runBacktest(backtestCommand)).isSameAs(backtestResult);
+            assertThat(portfolioFacade.getCorrelationMatrix(MEMBER_ID, PORTFOLIO_ID)).isSameAs(correlation);
+            assertThat(portfolioFacade.getPerformanceSinceInception(MEMBER_ID, PORTFOLIO_ID)).isSameAs(performance);
+            assertThat(portfolioFacade.getInceptionChart(MEMBER_ID, PORTFOLIO_ID)).isSameAs(chart);
+        }
     }
 
-    @Test
-    @DisplayName("포트폴리오 조회 요청은 LoadPortfolioUseCase로 위임한다")
-    void delegateLoadUseCase() {
-        PortfolioResponse portfolio = mock(PortfolioResponse.class);
-        List<PortfolioResponse> portfolios = List.of(portfolio);
-        given(loadPortfolioUseCase.getMyPortfolios(MEMBER_ID)).willReturn(portfolios);
-        given(loadPortfolioUseCase.getPortfolio(MEMBER_ID, PORTFOLIO_ID)).willReturn(portfolio);
+    @Nested
+    @DisplayName("포트폴리오 분석 및 요약 테스트")
+    class AnalysisTests {
 
-        assertThat(portfolioFacade.getMyPortfolios(MEMBER_ID)).isSameAs(portfolios);
-        assertThat(portfolioFacade.getPortfolio(MEMBER_ID, PORTFOLIO_ID)).isSameAs(portfolio);
-        verify(loadPortfolioUseCase).getMyPortfolios(MEMBER_ID);
-        verify(loadPortfolioUseCase).getPortfolio(MEMBER_ID, PORTFOLIO_ID);
+        @Test
+        @DisplayName("분석 요약 조회 시 날짜가 없으면 종료일은 오늘, 시작일은 12개월 전으로 보정한다")
+        void getAnalysisSummary_DefaultDateRange() {
+            PortfolioAnalysisSummaryResult summary = mock(PortfolioAnalysisSummaryResult.class);
+            given(portfolioAnalysisUseCase.getAnalysisSummary(
+                    eq(MEMBER_ID),
+                    eq(PORTFOLIO_ID),
+                    any(LocalDate.class),
+                    any(LocalDate.class)
+            )).willReturn(summary);
+
+            LocalDate beforeCall = LocalDate.now();
+            PortfolioAnalysisSummaryResult result = portfolioFacade.getAnalysisSummary(MEMBER_ID, PORTFOLIO_ID, null, null);
+            LocalDate afterCall = LocalDate.now();
+
+            ArgumentCaptor<LocalDate> startCaptor = ArgumentCaptor.forClass(LocalDate.class);
+            ArgumentCaptor<LocalDate> endCaptor = ArgumentCaptor.forClass(LocalDate.class);
+            verify(portfolioAnalysisUseCase).getAnalysisSummary(
+                    eq(MEMBER_ID),
+                    eq(PORTFOLIO_ID),
+                    startCaptor.capture(),
+                    endCaptor.capture()
+            );
+            assertThat(result).isSameAs(summary);
+            assertThat(endCaptor.getValue()).isBetween(beforeCall, afterCall);
+            assertThat(startCaptor.getValue()).isEqualTo(endCaptor.getValue().minusMonths(12));
+        }
     }
 
-    @Test
-    @DisplayName("포트폴리오 분석 요청은 PortfolioAnalysisUseCase로 위임한다")
-    void delegateAnalysisUseCase() {
-        PortfolioValuationResult valuation = mock(PortfolioValuationResult.class);
-        PortfolioDiversificationResult diversification = mock(PortfolioDiversificationResult.class);
-        PortfolioRebalancingResult rebalancing = mock(PortfolioRebalancingResult.class);
-        BacktestPortfolioCommand backtestCommand = mock(BacktestPortfolioCommand.class);
-        BacktestResult backtestResult = mock(BacktestResult.class);
-        Map<String, Map<String, BigDecimal>> correlation = Map.of("005930", Map.of("000660", BigDecimal.ONE));
-        PortfolioInceptionPerformanceResult performance = mock(PortfolioInceptionPerformanceResult.class);
-        PortfolioInceptionChartResult chart = mock(PortfolioInceptionChartResult.class);
+    @Nested
+    @DisplayName("AI 기능 토글 테스트")
+    class AiToggleTests {
 
-        given(portfolioAnalysisUseCase.getValuation(MEMBER_ID, PORTFOLIO_ID)).willReturn(valuation);
-        given(portfolioAnalysisUseCase.getDiversification(MEMBER_ID, PORTFOLIO_ID)).willReturn(diversification);
-        given(portfolioAnalysisUseCase.getRebalancingGuide(MEMBER_ID, PORTFOLIO_ID)).willReturn(rebalancing);
-        given(portfolioAnalysisUseCase.runBacktest(backtestCommand)).willReturn(backtestResult);
-        given(portfolioAnalysisUseCase.getCorrelationMatrix(MEMBER_ID, PORTFOLIO_ID)).willReturn(correlation);
-        given(portfolioAnalysisUseCase.getPerformanceSinceInception(MEMBER_ID, PORTFOLIO_ID)).willReturn(performance);
-        given(portfolioAnalysisUseCase.getInceptionChart(MEMBER_ID, PORTFOLIO_ID)).willReturn(chart);
+        @Test
+        @DisplayName("AI가 비활성화되면 진단과 조언은 Mock 응답을 반환하고 UseCase를 호출하지 않는다")
+        void returnMockResponsesWhenAiDisabled() {
+            ReflectionTestUtils.setField(portfolioFacade, "aiEnabled", false);
 
-        assertThat(portfolioFacade.getValuation(MEMBER_ID, PORTFOLIO_ID)).isSameAs(valuation);
-        assertThat(portfolioFacade.getDiversification(MEMBER_ID, PORTFOLIO_ID)).isSameAs(diversification);
-        assertThat(portfolioFacade.getRebalancingGuide(MEMBER_ID, PORTFOLIO_ID)).isSameAs(rebalancing);
-        assertThat(portfolioFacade.runBacktest(backtestCommand)).isSameAs(backtestResult);
-        assertThat(portfolioFacade.getCorrelationMatrix(MEMBER_ID, PORTFOLIO_ID)).isSameAs(correlation);
-        assertThat(portfolioFacade.getPerformanceSinceInception(MEMBER_ID, PORTFOLIO_ID)).isSameAs(performance);
-        assertThat(portfolioFacade.getInceptionChart(MEMBER_ID, PORTFOLIO_ID)).isSameAs(chart);
+            PortfolioHealthResult healthResult = portfolioFacade.diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID);
+            AdviceResponse latestAdvice = portfolioFacade.getLatestAdvice(MEMBER_ID, PORTFOLIO_ID);
+            AdviceResponse newAdvice = portfolioFacade.getNewAdvice(MEMBER_ID, PORTFOLIO_ID);
+
+            assertThat(healthResult.summary()).contains("Mock AI 진단");
+            assertThat(latestAdvice.content()).contains("Mock AI 조언");
+            assertThat(newAdvice.content()).contains("Mock AI 조언");
+            verifyNoInteractions(diagnosePortfolioUseCase, aiAdvisorUseCase);
+        }
+
+        @Test
+        @DisplayName("AI가 활성화되면 진단과 조언 요청은 각 UseCase로 위임한다")
+        void delegateAiUseCasesWhenAiEnabled() {
+            ReflectionTestUtils.setField(portfolioFacade, "aiEnabled", true);
+            PortfolioHealthResult healthResult = PortfolioHealthResult.mock();
+            AdviceResponse latestAdvice = AdviceResponse.mock();
+            AdviceResponse newAdvice = AdviceResponse.mock();
+            given(diagnosePortfolioUseCase.diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID)).willReturn(healthResult);
+            given(aiAdvisorUseCase.getLatestAdvice(MEMBER_ID, PORTFOLIO_ID)).willReturn(latestAdvice);
+            given(aiAdvisorUseCase.getNewAdvice(MEMBER_ID, PORTFOLIO_ID)).willReturn(newAdvice);
+
+            assertThat(portfolioFacade.diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID)).isSameAs(healthResult);
+            assertThat(portfolioFacade.getLatestAdvice(MEMBER_ID, PORTFOLIO_ID)).isSameAs(latestAdvice);
+            assertThat(portfolioFacade.getNewAdvice(MEMBER_ID, PORTFOLIO_ID)).isSameAs(newAdvice);
+            verify(diagnosePortfolioUseCase).diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID);
+            verify(aiAdvisorUseCase).getLatestAdvice(MEMBER_ID, PORTFOLIO_ID);
+            verify(aiAdvisorUseCase).getNewAdvice(MEMBER_ID, PORTFOLIO_ID);
+            verify(aiAdvisorUseCase, never()).generateBacktestAdvice(any(), any(), any());
+        }
     }
 
-    @Test
-    @DisplayName("분석 요약 조회 시 날짜가 없으면 종료일은 오늘, 시작일은 12개월 전으로 보정한다")
-    void getAnalysisSummary_DefaultDateRange() {
-        PortfolioAnalysisSummaryResult summary = mock(PortfolioAnalysisSummaryResult.class);
-        given(portfolioAnalysisUseCase.getAnalysisSummary(
-                org.mockito.ArgumentMatchers.eq(MEMBER_ID),
-                org.mockito.ArgumentMatchers.eq(PORTFOLIO_ID),
-                org.mockito.ArgumentMatchers.any(LocalDate.class),
-                org.mockito.ArgumentMatchers.any(LocalDate.class)
-        )).willReturn(summary);
-
-        LocalDate beforeCall = LocalDate.now();
-        PortfolioAnalysisSummaryResult result = portfolioFacade.getAnalysisSummary(MEMBER_ID, PORTFOLIO_ID, null, null);
-        LocalDate afterCall = LocalDate.now();
-
-        ArgumentCaptor<LocalDate> startCaptor = ArgumentCaptor.forClass(LocalDate.class);
-        ArgumentCaptor<LocalDate> endCaptor = ArgumentCaptor.forClass(LocalDate.class);
-        verify(portfolioAnalysisUseCase).getAnalysisSummary(
-                org.mockito.ArgumentMatchers.eq(MEMBER_ID),
-                org.mockito.ArgumentMatchers.eq(PORTFOLIO_ID),
-                startCaptor.capture(),
-                endCaptor.capture()
-        );
-        assertThat(result).isSameAs(summary);
-        assertThat(endCaptor.getValue()).isBetween(beforeCall, afterCall);
-        assertThat(startCaptor.getValue()).isEqualTo(endCaptor.getValue().minusMonths(12));
-    }
-
-    @Test
-    @DisplayName("AI가 비활성화되면 진단과 조언은 Mock 응답을 반환하고 UseCase를 호출하지 않는다")
-    void returnMockResponsesWhenAiDisabled() {
-        ReflectionTestUtils.setField(portfolioFacade, "aiEnabled", false);
-
-        PortfolioHealthResult healthResult = portfolioFacade.diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID);
-        AdviceResponse latestAdvice = portfolioFacade.getLatestAdvice(MEMBER_ID, PORTFOLIO_ID);
-        AdviceResponse newAdvice = portfolioFacade.getNewAdvice(MEMBER_ID, PORTFOLIO_ID);
-
-        assertThat(healthResult.summary()).contains("Mock AI 진단");
-        assertThat(latestAdvice.content()).contains("Mock AI 조언");
-        assertThat(newAdvice.content()).contains("Mock AI 조언");
-        verifyNoInteractions(diagnosePortfolioUseCase, aiAdvisorUseCase);
-    }
-
-    @Test
-    @DisplayName("AI가 활성화되면 진단과 조언 요청은 각 UseCase로 위임한다")
-    void delegateAiUseCasesWhenAiEnabled() {
-        ReflectionTestUtils.setField(portfolioFacade, "aiEnabled", true);
-        PortfolioHealthResult healthResult = PortfolioHealthResult.mock();
-        AdviceResponse latestAdvice = AdviceResponse.mock();
-        AdviceResponse newAdvice = AdviceResponse.mock();
-        given(diagnosePortfolioUseCase.diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID)).willReturn(healthResult);
-        given(aiAdvisorUseCase.getLatestAdvice(MEMBER_ID, PORTFOLIO_ID)).willReturn(latestAdvice);
-        given(aiAdvisorUseCase.getNewAdvice(MEMBER_ID, PORTFOLIO_ID)).willReturn(newAdvice);
-
-        assertThat(portfolioFacade.diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID)).isSameAs(healthResult);
-        assertThat(portfolioFacade.getLatestAdvice(MEMBER_ID, PORTFOLIO_ID)).isSameAs(latestAdvice);
-        assertThat(portfolioFacade.getNewAdvice(MEMBER_ID, PORTFOLIO_ID)).isSameAs(newAdvice);
-        verify(diagnosePortfolioUseCase).diagnosePortfolio(MEMBER_ID, PORTFOLIO_ID);
-        verify(aiAdvisorUseCase).getLatestAdvice(MEMBER_ID, PORTFOLIO_ID);
-        verify(aiAdvisorUseCase).getNewAdvice(MEMBER_ID, PORTFOLIO_ID);
-        verify(aiAdvisorUseCase, never()).generateBacktestAdvice(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    @Nested
+    @DisplayName("예외 전파 테스트")
+    class ExceptionTests {
     }
 }


### PR DESCRIPTION
## 요약
- PortfolioFacadeTest 클래스 구조를 JUnit 5 @Nested를 사용하여 관심사별로 리팩토링
- getAnalysisSummary 메서드의 날짜 보정 로직(시작일/종료일 누락 케이스) 전수 검증 추가
- AI 기능 활성화/비활성화 시나리오에 대한 일관된 UseCase 상호작용 차단 검증 강화
- UseCase 예외 발생 시 Facade를 통한 예외 전파 메커니즘 검증 추가

## 테스트 계획
- [x] DelegationTests 실행 (기본 위임 확인)
- [x] AnalysisTests 실행 (날짜 보정 시나리오 확인)
- [x] AiToggleTests 실행 (AI 활성화 여부에 따른 분기 확인)
- [x] ExceptionTests 실행 (예외 전파 확인)
- [x] 전체 빌드 및 테스트 확인 (./gradlew clean build)

Closes #233