### PR TITLE
feat(batch): 증시 기상도 7단계 세분화 및 섹터명 소급 매핑 구현

### DIFF
--- a/stockwellness-batch/src/main/java/org/stockwellness/adapter/batch/insight/MarketWeatherBackfillConfig.java
+++ b/stockwellness-batch/src/main/java/org/stockwellness/adapter/batch/insight/MarketWeatherBackfillConfig.java
@@ -17,14 +17,22 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.stockwellness.adapter.out.persistence.insight.MarketWeather;
 import org.stockwellness.adapter.out.persistence.insight.SectorIndicator;
+import org.stockwellness.adapter.out.persistence.insight.SectorWeather;
+import org.stockwellness.adapter.out.persistence.insight.repository.MarketWeatherRepository;
 import org.stockwellness.adapter.out.persistence.insight.repository.SectorIndicatorRepository;
+import org.stockwellness.adapter.out.persistence.insight.repository.SectorWeatherRepository;
+import org.stockwellness.adapter.out.persistence.stock.repository.SectorInsightRepository;
 import org.stockwellness.domain.stock.insight.SectorInsight;
+import org.stockwellness.domain.stock.insight.WeatherState;
 import org.stockwellness.global.util.DateUtil;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -36,11 +44,20 @@ public class MarketWeatherBackfillConfig {
     private final PlatformTransactionManager transactionManager;
     private final EntityManagerFactory entityManagerFactory;
     private final SectorIndicatorRepository sectorIndicatorRepository;
+    private final SectorWeatherRepository sectorWeatherRepository;
+    private final MarketWeatherRepository marketWeatherRepository;
+    private final SectorInsightRepository sectorInsightRepository;
 
     @Bean
-    public Job backfillMarketWeatherJob(Step backfillSectorIndicatorStep) {
+    public Job backfillMarketWeatherJob(
+            Step backfillSectorIndicatorStep,
+            Step backfillSectorWeatherStep,
+            Step backfillMarketWeatherStep
+    ) {
         return new JobBuilder("backfillMarketWeatherJob", jobRepository)
                 .start(backfillSectorIndicatorStep)
+                .next(backfillSectorWeatherStep)
+                .next(backfillMarketWeatherStep)
                 .build();
     }
 
@@ -56,6 +73,141 @@ public class MarketWeatherBackfillConfig {
                 .processor(backfillProcessor)
                 .writer(backfillWriter)
                 .build();
+    }
+
+    @Bean
+    public Step backfillSectorWeatherStep(
+            JpaPagingItemReader<SectorIndicator> sectorIndicatorReader,
+            ItemProcessor<SectorIndicator, SectorWeather> sectorWeatherProcessor,
+            ItemWriter<SectorWeather> sectorWeatherWriter
+    ) {
+        return new StepBuilder("backfillSectorWeatherStep", jobRepository)
+                .<SectorIndicator, SectorWeather>chunk(50, transactionManager)
+                .reader(sectorIndicatorReader)
+                .processor(sectorWeatherProcessor)
+                .writer(sectorWeatherWriter)
+                .build();
+    }
+
+    @Bean
+    public Step backfillMarketWeatherStep() {
+        return new StepBuilder("backfillMarketWeatherStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    String startDateStr = (String) chunkContext.getStepContext().getJobParameters().get("startDate");
+                    LocalDate startDate = DateUtil.parseFlexible(startDateStr);
+                    if (startDate == null) startDate = DateUtil.today().minusDays(365);
+
+                    // 일별로 섹터별 점수를 가져와서 시장 전체 기상도 생성
+                    LocalDate current = startDate;
+                    LocalDate end = DateUtil.today();
+
+                    while (!current.isAfter(end)) {
+                        List<SectorWeather> dailyWeathers = sectorWeatherRepository.findAllByBaseDate(current);
+                        if (!dailyWeathers.isEmpty()) {
+                            double avgScore = dailyWeathers.stream()
+                                    .mapToInt(SectorWeather::getWeatherScore)
+                                    .average()
+                                    .orElse(50.0);
+
+                            // 상위/하위 섹터 요약 (간소화)
+                            var sorted = dailyWeathers.stream()
+                                    .sorted((a, b) -> Integer.compare(b.getWeatherScore(), a.getWeatherScore()))
+                                    .toList();
+
+                            var topSectors = sorted.stream().limit(3)
+                                    .map(s -> new MarketWeather.SectorSummary(s.getSectorCode(), getSectorName(s.getSectorCode()), s.getWeatherScore(), WeatherState.fromScore(s.getWeatherScore()).getIconEmoji()))
+                                    .toList();
+
+                            var bottomSectors = sorted.stream().skip(Math.max(0, sorted.size() - 3))
+                                    .map(s -> new MarketWeather.SectorSummary(s.getSectorCode(), getSectorName(s.getSectorCode()), s.getWeatherScore(), WeatherState.fromScore(s.getWeatherScore()).getIconEmoji()))
+                                    .toList();
+
+                            MarketWeather marketWeather = MarketWeather.builder()
+                                    .baseDate(current)
+                                    .marketType("KOSPI") // 기본값
+                                    .weatherScore((int) avgScore)
+                                    .weatherState(WeatherState.fromScore((int) avgScore).getStateName())
+                                    .topSectors(topSectors)
+                                    .bottomSectors(bottomSectors)
+                                    .build();
+
+                            marketWeatherRepository.save(marketWeather);
+                        }
+                        current = current.plusDays(1);
+                    }
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .build();
+    }
+
+    private String getSectorName(String code) {
+        return sectorInsightRepository.findFirstBySectorCodeOrderByBaseDateDesc(code)
+                .map(si -> si.getSectorName())
+                .orElse(code);
+    }
+
+    @Bean
+    @StepScope
+    public JpaPagingItemReader<SectorIndicator> sectorIndicatorReader(
+            @Value("#{jobParameters['startDate']}") String startDateStr
+    ) {
+        LocalDate startDate = DateUtil.parseFlexible(startDateStr);
+        if (startDate == null) startDate = DateUtil.today().minusDays(365);
+
+        return new JpaPagingItemReaderBuilder<SectorIndicator>()
+                .name("sectorIndicatorReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT s FROM SectorIndicator s WHERE s.baseDate >= :startDate")
+                .parameterValues(Map.of("startDate", startDate))
+                .pageSize(50)
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<SectorIndicator, SectorWeather> sectorWeatherProcessor() {
+        return indicator -> {
+            // 점수 산출 로직: (이격도 점수 * 0.4) + (ADR 점수 * 0.3) + (RSI 점수 * 0.3)
+            int score = calculateScore(indicator);
+
+            return SectorWeather.builder()
+                    .baseDate(indicator.getBaseDate())
+                    .sectorCode(indicator.getSectorCode())
+                    .weatherScore(score)
+                    .weatherState(WeatherState.fromScore(score).getStateName())
+                    .build();
+        };
+    }
+
+    private int calculateScore(SectorIndicator indicator) {
+        double score = 50.0;
+
+        // 1. 이격도 (100 기준 +- 10% 범위)
+        if (indicator.getMa20Disparity() != null) {
+            double disp = indicator.getMa20Disparity().doubleValue();
+            double dispScore = Math.max(0, Math.min(100, (disp - 90) * 5)); // 90일때 0, 110일때 100
+            score = score * 0.6 + dispScore * 0.4;
+        }
+
+        // 2. RSI (30~70 기준)
+        if (indicator.getRsi14() != null) {
+            double rsi = indicator.getRsi14().doubleValue();
+            double rsiScore = rsi; // RSI 자체가 0~100 지표
+            score = score * 0.7 + rsiScore * 0.3;
+        }
+
+        // 3. ADR (100 기준 +- 20% 범위)
+        if (indicator.getAdr() != null) {
+            double adr = indicator.getAdr().doubleValue();
+            double adrScore = Math.max(0, Math.min(100, (adr - 80) * 2.5)); // 80일때 0, 120일때 100
+            score = score * 0.7 + adrScore * 0.3;
+        }
+
+        return (int) score;
+    }
+
+    @Bean
+    public ItemWriter<SectorWeather> sectorWeatherWriter() {
+        return items -> sectorWeatherRepository.saveAll(items);
     }
 
     @Bean

--- a/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/insight/repository/SectorWeatherRepository.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/insight/repository/SectorWeatherRepository.java
@@ -3,5 +3,9 @@ package org.stockwellness.adapter.out.persistence.insight.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.stockwellness.adapter.out.persistence.insight.SectorWeather;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface SectorWeatherRepository extends JpaRepository<SectorWeather, Long> {
+    List<SectorWeather> findAllByBaseDate(LocalDate baseDate);
 }

--- a/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/stock/repository/SectorInsightRepository.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/adapter/out/persistence/stock/repository/SectorInsightRepository.java
@@ -46,4 +46,6 @@ public interface SectorInsightRepository extends JpaRepository<SectorInsight, Lo
 
     @Query("SELECT MAX(s.baseDate) FROM SectorInsight s")
     Optional<LocalDate> findMaxBaseDate();
+
+    Optional<SectorInsight> findFirstBySectorCodeOrderByBaseDateDesc(String sectorCode);
 }

--- a/stockwellness-core/src/main/java/org/stockwellness/domain/stock/insight/WeatherState.java
+++ b/stockwellness-core/src/main/java/org/stockwellness/domain/stock/insight/WeatherState.java
@@ -1,46 +1,60 @@
 package org.stockwellness.domain.stock.insight;
 
-public sealed interface WeatherState permits WeatherState.Sunny, WeatherState.PartlyCloudy, WeatherState.Cloudy, WeatherState.Rainy, WeatherState.Storm {
+public sealed interface WeatherState permits WeatherState.Clear, WeatherState.Sunny, WeatherState.PartlyCloudy, WeatherState.Cloudy, WeatherState.Foggy, WeatherState.Rainy, WeatherState.Storm {
     
     String getIconEmoji();
     String getDescription();
     String getStateName();
     
-    record Sunny() implements WeatherState {
+    record Clear() implements WeatherState {
         @Override public String getIconEmoji() { return "☀️"; }
-        @Override public String getDescription() { return "안정적인 상승 추세"; }
+        @Override public String getDescription() { return "강력한 상승 장세"; }
+        @Override public String getStateName() { return "CLEAR"; }
+    }
+    
+    record Sunny() implements WeatherState {
+        @Override public String getIconEmoji() { return "🌤️"; }
+        @Override public String getDescription() { return "완만한 상승 추세"; }
         @Override public String getStateName() { return "SUNNY"; }
     }
     
     record PartlyCloudy() implements WeatherState {
-        @Override public String getIconEmoji() { return "⛅"; }
-        @Override public String getDescription() { return "상승 후 조심스러운 장세"; }
+        @Override public String getIconEmoji() { return "🌥️"; }
+        @Override public String getDescription() { return "상승 후 조심스러운 횡보"; }
         @Override public String getStateName() { return "PARTLY_CLOUDY"; }
     }
     
     record Cloudy() implements WeatherState {
-        @Override public String getIconEmoji() { return "☁️"; }
-        @Override public String getDescription() { return "방향성 탐색 구간"; }
+        @Override public String getIconEmoji() { return "⛅"; }
+        @Override public String getDescription() { return "방향성 탐색 중"; }
         @Override public String getStateName() { return "CLOUDY"; }
+    }
+
+    record Foggy() implements WeatherState {
+        @Override public String getIconEmoji() { return "🌫️"; }
+        @Override public String getDescription() { return "불확실성 증가 주의"; }
+        @Override public String getStateName() { return "FOGGY"; }
     }
     
     record Rainy() implements WeatherState {
         @Override public String getIconEmoji() { return "🌧️"; }
-        @Override public String getDescription() { return "하락 전환 주의"; }
+        @Override public String getDescription() { return "단기 하락 전환"; }
         @Override public String getStateName() { return "RAINY"; }
     }
     
     record Storm() implements WeatherState {
         @Override public String getIconEmoji() { return "⛈️"; }
-        @Override public String getDescription() { return "패닉 셀링 / 강한 하락"; }
+        @Override public String getDescription() { return "패닉 셀링 / 강력 하락"; }
         @Override public String getStateName() { return "STORMY"; }
     }
 
     static WeatherState fromScore(int score) {
-        if (score >= 80) return new Sunny();
+        if (score >= 90) return new Clear();
+        if (score >= 75) return new Sunny();
         if (score >= 60) return new PartlyCloudy();
         if (score >= 40) return new Cloudy();
-        if (score >= 20) return new Rainy();
+        if (score >= 25) return new Foggy();
+        if (score >= 10) return new Rainy();
         return new Storm();
     }
 }


### PR DESCRIPTION
## 📝 개요
증시 기상도 상태를 기존 5단계에서 7단계로 확장하고, 과거 1년치 데이터 소급 배치 시 실제 섹터 이름을 매핑하도록 로직을 개선했습니다.

## 🔗 관련 이슈
Closes #244

## 🛠️ 변경 사항
- 기상 상태(`WeatherState`)를 기존 5단계에서 7단계(CLEAR, SUNNY, PARTLY_CLOUDY, CLOUDY, FOGGY, RAINY, STORMY)로 확장
- 증시 기상도 과거 1년치 소급 배치 로직(`MarketWeatherBackfillConfig`) 추가 및 개선
- `SectorInsightRepository` 연동을 통해 기상도 데이터 저장 시 실제 섹터 이름 매핑 추가

## ✅ 셀프 체크리스트 (Self-Check)
- [x] 빌드 성공 여부 확인 (`./gradlew clean build`)
- [x] 단위/통합 테스트 통과 여부 확인
- [x] 로컬 환경에서 배치 정상 동작 확인
- [x] 기존 기능에 영향이 없는지 확인
