### PR TITLE
docs(README): 로컬 절대 경로 및 잘못된 링크 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 ## 개발 환경
 
-성능 측정 가이드는 [k6/README.md](/Users/chan/Desktop/gongbu/stockwellness-project/stockwellness/k6/README.md)를 참고합니다.
-백엔드 개발 작업 가이드는 [docs/backend-development-guide.md](/Users/chan/Desktop/gongbu/stockwellness-project/stockwellness/docs/backend-development-guide.md)를 참고합니다.
+성능 측정 가이드는 [k6/README.md](./k6/README.md)를 참고합니다.
+백엔드 개발 작업 가이드는 [docs/backend-development-guide.md](./docs/backend-development-guide.md)를 참고합니다.
 
 ### Language
 ![Java](https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white)
@@ -51,7 +51,7 @@
 - 매 영업일 장 마감 후 한국투자증권 KIS API에서 일일 시세(EOD) 수집
 - RSI, MACD 등 기술 지표를 배치 단계에서 사전 계산하여 저장 (ta4j 활용)
 - Virtual Threads 기반 병렬 처리로 대량 종목 데이터 수집 속도 최적화
-- 운영 점검 런북: `docs/qa/qa-stockwellness-scheduler.md`
+- 운영 점검 런북: [../docs/qa/qa-stockwellness-scheduler.md](../docs/qa/qa-stockwellness-scheduler.md)
 
 ### 4. PortfolioFacade 기반 통합 오케스트레이션
 - 포트폴리오 백테스트, 건강 진단(MDD·Sharpe·Beta), 리밸런싱, AI 어드바이저를 단일 Facade로 통합


### PR DESCRIPTION
## 개요
stockwellness/README.md 파일 내의 로컬 절대 경로를 상대 경로로 수정하고, 잘못된 런북 참조를 클릭 가능한 링크로 개선했습니다.

## 변경 사항
- k6/README.md 링크 수정 (절대 경로 -> 상대 경로)
- docs/backend-development-guide.md 링크 수정 (절대 경로 -> 상대 경로)
- docs/qa/qa-stockwellness-scheduler.md 링크 수정 (텍스트 -> 상대 경로 링크)

## 관련 이슈
- Close #252